### PR TITLE
MM-56776 Update mock to fix ChannelHasBeenCreated not being called for GMs

### DIFF
--- a/server/automute_channel_test.go
+++ b/server/automute_channel_test.go
@@ -175,8 +175,6 @@ func TestUpdateAutomutingOnChannelCreated(t *testing.T) {
 	})
 
 	t.Run("when a GM is created, should mute it for users with automuting enabled", func(t *testing.T) {
-		t.Skip("not working due to MM-56776")
-
 		p := newAutomuteTestPlugin(t)
 
 		channel := &model.Channel{

--- a/server/automute_test.go
+++ b/server/automute_test.go
@@ -57,10 +57,7 @@ func (a *AutomuteAPIMock) CreateChannel(channel *model.Channel) (*model.Channel,
 
 	a.channels[channel.Id] = channel
 
-	// This should be called for all channels, but due to MM-56776, it's currently not called for GM channels
-	if channel.Type != model.ChannelTypeGroup {
-		a.plugin.ChannelHasBeenCreated(&plugin.Context{}, channel)
-	}
+	a.plugin.ChannelHasBeenCreated(&plugin.Context{}, channel)
 
 	return channel, nil
 }


### PR DESCRIPTION
#### Summary
I made `AutomuteAPIMock` match the server behaviour in MM-56776, so once https://github.com/mattermost/mattermost/pull/26226 goes in, the mock can also be "fixed". At the moment, we're planning for that fix to ship in 9.6, so fixing the corresponding bug on the MS Teams plugin (newly created GMs won't have automuting applied) will simply require upgrading to MM 9.6 once that's out

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56776
