### PR TITLE
MM-56926: always allow choice of primary platform

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -61,13 +61,16 @@ export default class Plugin {
         registry.registerAdminConsoleCustomSetting('appManifestDownload', MSTeamsAppManifestSetting);
         registry.registerAdminConsoleCustomSetting('ConnectedUsersReportDownload', ListConnectedUsers);
 
-        let settingsEnabled = (state as any)[`plugins-${manifest.id}`]?.connectedStateSlice?.connected || false; //TODO use connected selector from https://github.com/mattermost/mattermost-plugin-msteams/pull/438
+        // let settingsEnabled = (state as any)[`plugins-${manifest.id}`]?.connectedStateSlice?.connected || false; //TODO use connected selector from https://github.com/mattermost/mattermost-plugin-msteams/pull/438
+        let settingsEnabled = true;
         registry.registerUserSettings?.(getSettings(serverRoute, !settingsEnabled));
 
         this.removeStoreSubscription = store.subscribe(() => {
             const newState = store.getState();
             const newServerRoute = getServerRoute(newState);
-            const newSettingsEnabled = (newState as any)[`plugins-${manifest.id}`]?.connectedStateSlice?.connected || false; //TODO use connected selector from https://github.com/mattermost/mattermost-plugin-msteams/pull/438
+
+            // const newSettingsEnabled = (newState as any)[`plugins-${manifest.id}`]?.connectedStateSlice?.connected || false; //TODO use connected selector from https://github.com/mattermost/mattermost-plugin-msteams/pull/438
+            const newSettingsEnabled = true;
             if (newServerRoute !== serverRoute || newSettingsEnabled !== settingsEnabled) {
                 serverRoute = newServerRoute;
                 settingsEnabled = newSettingsEnabled;


### PR DESCRIPTION
#### Summary
Temporarily allow users to choose their primary platform even before connecting MS Teams, as we don't have the state needed in Redux to make that decision.

See https://hub.mattermost.com/private-core/pl/5rzr6p1uy7youpybnhx1f5u8rr for context.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-56926