### PR TITLE
fix closeInfoPage to call on promise resolution

### DIFF
--- a/assets/info-page/index.html
+++ b/assets/info-page/index.html
@@ -52,7 +52,7 @@
         const apiEndpoint = "{{.APIEndPoint}}";
         const queryParam = "{{.QueryParamPrimaryPlatform}}";
         fetch(`${serverURL}${apiEndpoint}?${queryParam}=${primaryPlatform}`)
-        .then(closeInfoPage());
+        .then(closeInfoPage);
       }
     </script>
     <style>


### PR DESCRIPTION
#### Summary
I regressed the behaviour, which closed the window before the promise was resolved. In my case, since the window never actually closed, the fetch had a chance to succeed. On browsers that honoured `window.close`, the `fetch` was interrupted and the settings never saved.

#### Ticket Link
None yet.