### PR TITLE
Allow self chats to sync when selective sync is true

### DIFF
--- a/server/selective_sync.go
+++ b/server/selective_sync.go
@@ -20,6 +20,11 @@ func (p *Plugin) ChatSpansPlatforms(channelID string) (bool, *model.AppError) {
 // ChatMembersSpanPlatforms determines if the given channel members span both Mattermost and
 // MS Teams. Chats between users on the same platform are skipped if selective sync is enabled.
 func (p *Plugin) ChatMembersSpanPlatforms(members model.ChannelMembers) (bool, *model.AppError) {
+	if len(members) == 1 {
+		// if self channel, allow to
+		return true, nil
+	}
+
 	atLeastOneLocalUser := false
 	atLeastOneRemoteUser := false
 	for _, m := range members {

--- a/server/selective_sync.go
+++ b/server/selective_sync.go
@@ -19,9 +19,9 @@ func (p *Plugin) ChatSpansPlatforms(channelID string) (bool, *model.AppError) {
 
 // ChatMembersSpanPlatforms determines if the given channel members span both Mattermost and
 // MS Teams. Chats between users on the same platform are skipped if selective sync is enabled.
+// Chats with only a single member are self chats and always sync.
 func (p *Plugin) ChatMembersSpanPlatforms(members model.ChannelMembers) (bool, *model.AppError) {
 	if len(members) == 1 {
-		// if self channel, allow to
 		return true, nil
 	}
 

--- a/server/selective_sync_test.go
+++ b/server/selective_sync_test.go
@@ -276,6 +276,18 @@ func TestChatMembersSpanPlatforms(t *testing.T) {
 		require.False(t, chatMembersSpanPlatforms)
 	})
 
+	t.Run("single local user", func(t *testing.T) {
+		team := setupTeam(t, p)
+		user1 := setupUser(t, p, team, false)
+
+		chatSpansPlatforms, appErr := p.ChatMembersSpanPlatforms(model.ChannelMembers{
+			model.ChannelMember{UserId: user1.Id},
+		})
+
+		require.Nil(t, appErr)
+		assert.True(t, chatSpansPlatforms)
+	})
+
 	t.Run("dm between two local users", func(t *testing.T) {
 		team := setupTeam(t, p)
 		user1 := setupUser(t, p, team, false)


### PR DESCRIPTION
#### Summary
Currently, with Selective Sync turned on, self chats will never sync. This is actually a valuable test tool and may people may "test" the system using there self channels. 

This PR checks the number of members in the channel and allows it to sync if there is only 1.



