### PR TITLE
[MM-57072] Use ConstantTimeCompare to prevent timing attack

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -221,7 +221,8 @@ func (a *API) processLifecycle(w http.ResponseWriter, req *http.Request) {
 
 	errors := ""
 	for _, event := range lifecycleEvents.Value {
-		if subtle.ConstantTimeCompare([]byte(event.ClientState), []byte(a.p.getConfiguration().WebhookSecret)) != 1 {
+		// Check the webhook secret using ContantTimeCompare to prevent timing attacks
+		if subtle.ConstantTimeCompare([]byte(event.ClientState), []byte(a.p.getConfiguration().WebhookSecret)) == 0 {
 			a.p.metricsService.ObserveLifecycleEvent(event.LifecycleEvent, metrics.DiscardedReasonInvalidWebhookSecret)
 			errors += "Invalid webhook secret"
 			continue

--- a/server/api.go
+++ b/server/api.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha1" //nolint:gosec
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/csv"
 	"encoding/json"
@@ -220,7 +221,7 @@ func (a *API) processLifecycle(w http.ResponseWriter, req *http.Request) {
 
 	errors := ""
 	for _, event := range lifecycleEvents.Value {
-		if event.ClientState != a.p.getConfiguration().WebhookSecret {
+		if subtle.ConstantTimeCompare([]byte(event.ClientState), []byte(a.p.getConfiguration().WebhookSecret)) != 1 {
 			a.p.metricsService.ObserveLifecycleEvent(event.LifecycleEvent, metrics.DiscardedReasonInvalidWebhookSecret)
 			errors += "Invalid webhook secret"
 			continue


### PR DESCRIPTION
#### Summary
Use `ConstantTimeCompare` instead of `!=` to reduce the risk of timing attacks on the webhook secret

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57072

