### PR TITLE
[MM-56908] Make promote command accepts @ for both arguments

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -598,16 +598,10 @@ func (p *Plugin) executePromoteUserCommand(args *model.CommandArgs, parameters [
 		return &model.CommandResponse{}, nil
 	}
 
-	username := parameters[0]
-	newUsername := parameters[1]
+	username := strings.TrimPrefix(parameters[0], "@")
+	newUsername := strings.TrimPrefix(parameters[1], "@")
 
-	var user *model.User
-	var appErr *model.AppError
-	if strings.HasPrefix(username, "@") {
-		user, appErr = p.API.GetUserByUsername(username[1:])
-	} else {
-		user, appErr = p.API.GetUserByUsername(username)
-	}
+	user, appErr := p.API.GetUserByUsername(username)
 	if appErr != nil {
 		p.sendBotEphemeralPost(args.UserId, args.ChannelId, "Error: Unable to promote account "+username+", user not found")
 		return &model.CommandResponse{}, nil

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -1429,8 +1429,35 @@ func TestExecutePromoteCommand(t *testing.T) {
 			},
 		},
 		{
+			description: "Valid user and valid new username, submitted with a @",
+			params:      []string{"@valid-user", "@new-user"},
+			setupAPI: func(api *plugintest.API) {
+				api.On("HasPermissionTo", testutils.GetUserID(), model.PermissionManageSystem).Return(true).Times(1)
+				api.On("GetUserByUsername", "valid-user").Return(&model.User{Id: "test", Username: "valid-user", RemoteId: model.NewString("remote-id")}, nil).Once()
+				api.On("GetUserByUsername", "new-user").Return(nil, &model.AppError{}).Once()
+				api.On("UpdateUser", &model.User{Id: "test", Username: "new-user", RemoteId: nil}).Return(&model.User{Id: "test", Username: "new-user", RemoteId: nil}, nil).Once()
+				api.On("SendEphemeralPost", testutils.GetUserID(), testutils.GetEphemeralPost(p.userID, testutils.GetChannelID(), "Account valid-user has been promoted and updated the username to new-user")).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro())).Once()
+			},
+			setupStore: func(s *mockStore.Store) {
+				s.On("MattermostToTeamsUserID", "test").Return("ms-test", nil).Times(1)
+			},
+		},
+		{
 			description: "Valid user and valid new username with same username",
 			params:      []string{"valid-user", "valid-user"},
+			setupAPI: func(api *plugintest.API) {
+				api.On("HasPermissionTo", testutils.GetUserID(), model.PermissionManageSystem).Return(true).Times(1)
+				api.On("GetUserByUsername", "valid-user").Return(&model.User{Id: "test", Username: "valid-user", RemoteId: model.NewString("remote-id")}, nil).Times(2)
+				api.On("UpdateUser", &model.User{Id: "test", Username: "valid-user", RemoteId: nil}).Return(&model.User{Id: "test", Username: "valid-user", RemoteId: nil}, nil).Times(1)
+				api.On("SendEphemeralPost", testutils.GetUserID(), testutils.GetEphemeralPost(p.userID, testutils.GetChannelID(), "Account valid-user has been promoted and updated the username to valid-user")).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro())).Once()
+			},
+			setupStore: func(s *mockStore.Store) {
+				s.On("MattermostToTeamsUserID", "test").Return("ms-test", nil).Times(1)
+			},
+		},
+		{
+			description: "Valid user and valid new username, submitted with a @",
+			params:      []string{"@valid-user", "@valid-user"},
 			setupAPI: func(api *plugintest.API) {
 				api.On("HasPermissionTo", testutils.GetUserID(), model.PermissionManageSystem).Return(true).Times(1)
 				api.On("GetUserByUsername", "valid-user").Return(&model.User{Id: "test", Username: "valid-user", RemoteId: model.NewString("remote-id")}, nil).Times(2)


### PR DESCRIPTION
#### Summary
When running the `promote` command, the first argument is accepted with or without a `@`, while the second does not support a `@` at all. This PR allows both arguments to be prefixed by a `@`, that will immediately be trimmed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56908
