### PR TITLE
MM-56811: notify when attachments not synced

### DIFF
--- a/server/ce2e/plugin_test.go
+++ b/server/ce2e/plugin_test.go
@@ -263,7 +263,7 @@ func TestMessageHasBeenPostedNewDirectMessageE2E(t *testing.T) {
 			if assert.NoError(c, err) {
 				assert.Equal(c, newPostID, postInfo.MSTeamsID)
 			}
-		}, 1*time.Second, 50*time.Millisecond)
+		}, 5*time.Second, 50*time.Millisecond)
 	})
 
 	t.Run("Failing to deliver message to MSTeams", func(t *testing.T) {

--- a/server/handlers/attachments.go
+++ b/server/handlers/attachments.go
@@ -142,11 +142,13 @@ func (ah *ActivityHandler) handleAttachments(channelID, userID, text string, msg
 			continue
 		}
 
-		if isUpdatedActivity {
+		if !ah.plugin.GetSyncFileAttachments() {
+			skippedFileAttachments = true
 			continue
 		}
 
-		if !ah.plugin.GetSyncFileAttachments() {
+		// We don't support retroactively adding file attachments to posts.
+		if isUpdatedActivity {
 			skippedFileAttachments = true
 			continue
 		}

--- a/server/handlers/converters.go
+++ b/server/handlers/converters.go
@@ -13,7 +13,7 @@ import (
 
 const hostedContentsStr = "hostedContents"
 
-func (ah *ActivityHandler) msgToPost(channelID, senderID string, msg *clientmodels.Message, chat *clientmodels.Chat, isUpdatedActivity bool) (*model.Post, bool) {
+func (ah *ActivityHandler) msgToPost(channelID, senderID string, msg *clientmodels.Message, chat *clientmodels.Chat, isUpdatedActivity bool) (*model.Post, bool, bool) {
 	text := ah.handleMentions(msg)
 	text = ah.handleEmojis(text)
 	var embeddedImages []clientmodels.Attachment
@@ -30,7 +30,7 @@ func (ah *ActivityHandler) msgToPost(channelID, senderID string, msg *clientmode
 		}
 	}
 
-	newText, attachments, parentID, errorFound := ah.handleAttachments(channelID, senderID, text, msg, chat, isUpdatedActivity)
+	newText, attachments, parentID, skippedFileAttachments, errorFound := ah.handleAttachments(channelID, senderID, text, msg, chat, isUpdatedActivity)
 	text = newText
 	if parentID != "" {
 		rootID = parentID
@@ -49,7 +49,7 @@ func (ah *ActivityHandler) msgToPost(channelID, senderID string, msg *clientmode
 	if senderID == ah.plugin.GetBotUserID() {
 		post.AddProp("from_webhook", "true")
 	}
-	return post, errorFound
+	return post, skippedFileAttachments, errorFound
 }
 
 func (ah *ActivityHandler) handleMentions(msg *clientmodels.Message) string {

--- a/server/handlers/converters_test.go
+++ b/server/handlers/converters_test.go
@@ -79,7 +79,7 @@ func TestMsgToPost(t *testing.T) {
 
 			ah.plugin = p
 
-			post, _ := ah.msgToPost(testCase.channelID, testCase.senderID, testCase.message, nil, false)
+			post, _, _ := ah.msgToPost(testCase.channelID, testCase.senderID, testCase.message, nil, false)
 			assert.Equal(t, testCase.post, post)
 		})
 	}

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -362,7 +362,7 @@ func (ah *ActivityHandler) handleCreatedActivity(msg *clientmodels.Message, subs
 		_, appErr := ah.plugin.GetAPI().CreatePost(&model.Post{
 			ChannelId: newPost.ChannelId,
 			UserId:    ah.plugin.GetBotUserID(),
-			Message:   "Attachments sent from Microsoft Teams weren't delivered to Mattermost.",
+			Message:   "Attachments sent from Microsoft Teams aren't delivered to Mattermost.",
 			CreateAt:  newPost.CreateAt,
 		})
 		if appErr != nil {
@@ -475,7 +475,7 @@ func (ah *ActivityHandler) handleUpdatedActivity(msg *clientmodels.Message, subs
 		_, appErr := ah.plugin.GetAPI().CreatePost(&model.Post{
 			ChannelId: post.ChannelId,
 			UserId:    ah.plugin.GetBotUserID(),
-			Message:   "Attachments added to an existing post in Microsoft Teams weren't delivered to Mattermost.",
+			Message:   "Attachments added to an existing post in Microsoft Teams aren't delivered to Mattermost.",
 			CreateAt:  post.CreateAt,
 		})
 		if appErr != nil {

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -363,7 +363,8 @@ func (ah *ActivityHandler) handleCreatedActivity(msg *clientmodels.Message, subs
 			ChannelId: newPost.ChannelId,
 			UserId:    ah.plugin.GetBotUserID(),
 			Message:   "Attachments sent from Microsoft Teams aren't delivered to Mattermost.",
-			CreateAt:  newPost.CreateAt,
+			// Anchor the post immediately after (never before) the post that was created.
+			CreateAt: newPost.CreateAt + 1,
 		})
 		if appErr != nil {
 			ah.plugin.GetAPI().LogWarn("Failed to notify channel of skipped attachment", "channel_id", post.ChannelId, "post_id", newPost.Id, "error", appErr)
@@ -476,7 +477,8 @@ func (ah *ActivityHandler) handleUpdatedActivity(msg *clientmodels.Message, subs
 			ChannelId: post.ChannelId,
 			UserId:    ah.plugin.GetBotUserID(),
 			Message:   "Attachments added to an existing post in Microsoft Teams aren't delivered to Mattermost.",
-			CreateAt:  post.CreateAt,
+			// Anchor the post immediately after (never before) the post that was edited.
+			CreateAt: post.CreateAt + 1,
 		})
 		if appErr != nil {
 			ah.plugin.GetAPI().LogWarn("Failed to notify channel of skipped attachment", "channel_id", post.ChannelId, "post_id", post.Id, "error", appErr)

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -362,7 +362,7 @@ func (ah *ActivityHandler) handleCreatedActivity(msg *clientmodels.Message, subs
 		_, appErr := ah.plugin.GetAPI().CreatePost(&model.Post{
 			ChannelId: newPost.ChannelId,
 			UserId:    ah.plugin.GetBotUserID(),
-			Message:   "One or more attachments sent from Microsoft Teams were not delivered to Mattermost.",
+			Message:   "Attachments sent from Microsoft Teams weren't delivered to Mattermost.",
 			CreateAt:  newPost.CreateAt,
 		})
 		if appErr != nil {
@@ -475,7 +475,7 @@ func (ah *ActivityHandler) handleUpdatedActivity(msg *clientmodels.Message, subs
 		_, appErr := ah.plugin.GetAPI().CreatePost(&model.Post{
 			ChannelId: post.ChannelId,
 			UserId:    ah.plugin.GetBotUserID(),
-			Message:   "One or more attachments added to an existing post in Microsoft Teams were not delivered to Mattermost.",
+			Message:   "Attachments added to an existing post in Microsoft Teams weren't delivered to Mattermost.",
 			CreateAt:  post.CreateAt,
 		})
 		if appErr != nil {

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -484,34 +484,42 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 	}
 
 	var attachments []*clientmodels.Attachment
-	for _, fileID := range post.FileIds {
-		if !p.GetSyncFileAttachments() {
-			continue
-		}
+	if p.GetSyncFileAttachments() {
+		for _, fileID := range post.FileIds {
+			fileInfo, appErr := p.API.GetFileInfo(fileID)
+			if appErr != nil {
+				p.API.LogWarn("Unable to get file info", "error", appErr)
+				p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToGetMMData, true)
+				continue
+			}
+			fileData, appErr := p.API.GetFile(fileInfo.Id)
+			if appErr != nil {
+				p.API.LogWarn("Error in getting file attachment from Mattermost", "error", appErr)
+				p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToGetMMData, true)
+				continue
+			}
 
-		fileInfo, appErr := p.API.GetFileInfo(fileID)
+			fileName, fileExtension := getFileNameAndExtension(fileInfo.Name)
+			var attachment *clientmodels.Attachment
+			attachment, err = client.UploadFile("", "", fileName+"_"+fileInfo.Id+fileExtension, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData), chat)
+			if err != nil {
+				p.API.LogWarn("Error in uploading file attachment to MS Teams", "error", err)
+				p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToUploadFileOnTeams, true)
+				continue
+			}
+			attachments = append(attachments, attachment)
+			p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, "", true)
+		}
+	} else if len(post.FileIds) > 0 {
+		_, appErr := p.API.CreatePost(&model.Post{
+			ChannelId: post.ChannelId,
+			UserId:    p.GetBotUserID(),
+			Message:   "Attachments sent from Mattermost are not yet delivered to Microsoft Teams.",
+			CreateAt:  post.CreateAt,
+		})
 		if appErr != nil {
-			p.API.LogWarn("Unable to get file info", "error", appErr)
-			p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToGetMMData, true)
-			continue
+			p.API.LogWarn("Failed to notify channel of skipped attachment", "channel_id", post.ChannelId, "post_id", post.Id, "error", appErr)
 		}
-		fileData, appErr := p.API.GetFile(fileInfo.Id)
-		if appErr != nil {
-			p.API.LogWarn("Error in getting file attachment from Mattermost", "error", appErr)
-			p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToGetMMData, true)
-			continue
-		}
-
-		fileName, fileExtension := getFileNameAndExtension(fileInfo.Name)
-		var attachment *clientmodels.Attachment
-		attachment, err = client.UploadFile("", "", fileName+"_"+fileInfo.Id+fileExtension, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData), chat)
-		if err != nil {
-			p.API.LogWarn("Error in uploading file attachment to MS Teams", "error", err)
-			p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToUploadFileOnTeams, true)
-			continue
-		}
-		attachments = append(attachments, attachment)
-		p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, "", true)
 	}
 
 	md := markdown.New(markdown.XHTMLOutput(true), markdown.Typographer(false))
@@ -582,34 +590,43 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 	}
 
 	var attachments []*clientmodels.Attachment
-	for _, fileID := range post.FileIds {
-		if !p.GetSyncFileAttachments() {
-			continue
-		}
 
-		fileInfo, appErr := p.API.GetFileInfo(fileID)
-		if appErr != nil {
-			p.API.LogWarn("Unable to get file info", "error", appErr)
-			p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToGetMMData, false)
-			continue
-		}
-		fileData, appErr := p.API.GetFile(fileInfo.Id)
-		if appErr != nil {
-			p.API.LogWarn("Error in getting file attachment from Mattermost", "error", appErr)
-			p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToGetMMData, false)
-			continue
-		}
+	if p.GetSyncFileAttachments() {
+		for _, fileID := range post.FileIds {
+			fileInfo, appErr := p.API.GetFileInfo(fileID)
+			if appErr != nil {
+				p.API.LogWarn("Unable to get file info", "error", appErr)
+				p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToGetMMData, false)
+				continue
+			}
+			fileData, appErr := p.API.GetFile(fileInfo.Id)
+			if appErr != nil {
+				p.API.LogWarn("Error in getting file attachment from Mattermost", "error", appErr)
+				p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToGetMMData, false)
+				continue
+			}
 
-		fileName, fileExtension := getFileNameAndExtension(fileInfo.Name)
-		var attachment *clientmodels.Attachment
-		attachment, err = client.UploadFile(teamID, channelID, fileName+"_"+fileInfo.Id+fileExtension, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData), nil)
-		if err != nil {
-			p.API.LogWarn("Error in uploading file attachment to MS Teams", "error", err)
-			p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToUploadFileOnTeams, false)
-			continue
+			fileName, fileExtension := getFileNameAndExtension(fileInfo.Name)
+			var attachment *clientmodels.Attachment
+			attachment, err = client.UploadFile(teamID, channelID, fileName+"_"+fileInfo.Id+fileExtension, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData), nil)
+			if err != nil {
+				p.API.LogWarn("Error in uploading file attachment to MS Teams", "error", err)
+				p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToUploadFileOnTeams, false)
+				continue
+			}
+			attachments = append(attachments, attachment)
+			p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, "", false)
 		}
-		attachments = append(attachments, attachment)
-		p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, "", false)
+	} else if len(post.FileIds) > 0 {
+		_, appErr := p.API.CreatePost(&model.Post{
+			ChannelId: post.ChannelId,
+			UserId:    p.GetBotUserID(),
+			Message:   "Attachments sent from Mattermost are not yet delivered to Microsoft Teams.",
+			CreateAt:  post.CreateAt,
+		})
+		if appErr != nil {
+			p.API.LogWarn("Failed to notify channel of skipped attachment", "channel_id", channelID, "post_id", post.Id, "error", appErr)
+		}
 	}
 
 	md := markdown.New(markdown.XHTMLOutput(true), markdown.Typographer(false))

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -621,7 +621,7 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 		_, appErr := p.API.CreatePost(&model.Post{
 			ChannelId: post.ChannelId,
 			UserId:    p.GetBotUserID(),
-			Message:   "Attachments sent from Mattermost are not yet delivered to Microsoft Teams.",
+			Message:   "Attachments sent from Mattermost aren't yet delivered to Microsoft Teams.",
 			CreateAt:  post.CreateAt,
 		})
 		if appErr != nil {

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -514,7 +514,7 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 		_, appErr := p.API.CreatePost(&model.Post{
 			ChannelId: post.ChannelId,
 			UserId:    p.GetBotUserID(),
-			Message:   "Attachments sent from Mattermost are not yet delivered to Microsoft Teams.",
+			Message:   "Attachments sent from Mattermost aren't yet delivered to Microsoft Teams.",
 			CreateAt:  post.CreateAt,
 		})
 		if appErr != nil {

--- a/server/message_hooks_test.go
+++ b/server/message_hooks_test.go
@@ -1442,7 +1442,7 @@ func TestSendChat(t *testing.T) {
 			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("CreatePost", mock.MatchedBy(func(post *model.Post) bool {
-					return post.Message == "Attachments sent from Mattermost are not yet delivered to Microsoft Teams."
+					return post.Message == "Attachments sent from Mattermost aren't yet delivered to Microsoft Teams."
 				})).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), 0), nil).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
@@ -1687,7 +1687,7 @@ func TestSend(t *testing.T) {
 			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("CreatePost", mock.MatchedBy(func(post *model.Post) bool {
-					return post.Message == "Attachments sent from Mattermost are not yet delivered to Microsoft Teams."
+					return post.Message == "Attachments sent from Mattermost aren't yet delivered to Microsoft Teams."
 				})).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), 0), nil).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {

--- a/server/message_hooks_test.go
+++ b/server/message_hooks_test.go
@@ -1441,6 +1441,9 @@ func TestSendChat(t *testing.T) {
 				p.configuration.SyncFileAttachments = false
 			},
 			SetupAPI: func(api *plugintest.API) {
+				api.On("CreatePost", mock.MatchedBy(func(post *model.Post) bool {
+					return post.Message == "Attachments sent from Mattermost are not yet delivered to Microsoft Teams."
+				})).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), 0), nil).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
 				store.On("GetPostInfoByMattermostID", "mockRootID").Return(nil, nil).Once()
@@ -1683,6 +1686,9 @@ func TestSend(t *testing.T) {
 				p.configuration.SyncFileAttachments = false
 			},
 			SetupAPI: func(api *plugintest.API) {
+				api.On("CreatePost", mock.MatchedBy(func(post *model.Post) bool {
+					return post.Message == "Attachments sent from Mattermost are not yet delivered to Microsoft Teams."
+				})).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), 0), nil).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
 				store.On("GetTokenForMattermostUser", testutils.GetID()).Return(&fakeToken, nil).Times(1)


### PR DESCRIPTION
#### Summary
Don't surprise end users if file attachments are disabled by simply ignoring them: send a message (inside Mattermost) if a file attachment from Teams is skipped or if a user tries to send an attachment from Mattermost.

**sent from Teams**
![CleanShot 2024-03-18 at 14 53 59@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/797bade6-6311-4527-9dab-050cf22656aa)


**sent from Mattermost**
![CleanShot 2024-03-18 at 14 54 07@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/2e7da2b2-e1af-4e58-8118-4064fd767e0d)

This is not sent as an ephemeral message, partly since it applies to all channel participants, but also because an ephemeral message will disappear on reload.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-56811