### PR TITLE
use IsGroupOrDirect for clarity

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -159,7 +159,7 @@ func (p *Plugin) executeLinkCommand(args *model.CommandArgs, parameters []string
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to get the current channel information.")
 	}
 
-	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
+	if channel.IsGroupOrDirect() {
 		return p.cmdError(args.UserId, args.ChannelId, "Linking/unlinking a direct or group message is not allowed")
 	}
 
@@ -257,7 +257,7 @@ func (p *Plugin) executeUnlinkCommand(args *model.CommandArgs) (*model.CommandRe
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to get the current channel information.")
 	}
 
-	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
+	if channel.IsGroupOrDirect() {
 		return p.cmdError(args.UserId, args.ChannelId, "Linking/unlinking a direct or group message is not allowed")
 	}
 


### PR DESCRIPTION
#### Summary
In working through some changes to address invalid "error" logs, I took the opportunity to rely on `channel.IsGroupOrDirect()` to replace the manual comparisons. There should be no semantic changes from this PR.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-56719