### PR TITLE
update Grafana dashboard for Cloud, stripping out hard-coded links

### DIFF
--- a/server/metrics/dashboards/cloud.json
+++ b/server/metrics/dashboards/cloud.json
@@ -63,7 +63,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 306,
+  "id": 333,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -77,8 +77,204 @@
       },
       "id": 9,
       "panels": [],
-      "title": "Overview",
+      "title": "MS Teams Plugin",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 18,
+        "x": 0,
+        "y": 1
+      },
+      "id": 47,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "/.*/",
+          "values": true
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "P26CC1605805D4DDB"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT name FROM installation WHERE id IN ('${namespace}') LIMIT 50 ",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [
+                  {
+                    "name": "name",
+                    "type": "functionParameter"
+                  }
+                ],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50,
+            "whereJsonTree": {
+              "children1": [
+                {
+                  "id": "a89aabba-cdef-4012-b456-718cfa4edce2",
+                  "properties": {
+                    "field": "id",
+                    "fieldSrc": "field",
+                    "operator": "select_any_in",
+                    "value": [
+                      "$namespace"
+                    ],
+                    "valueSrc": [
+                      "value"
+                    ],
+                    "valueType": [
+                      "text"
+                    ]
+                  },
+                  "type": "rule"
+                }
+              ],
+              "id": "a88bb99b-89ab-4cde-b012-318cfa4e3aee",
+              "type": "group"
+            },
+            "whereString": "id IN ('$namespace')"
+          },
+          "table": "installation"
+        },
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "PD3C1F3F471EC7DA9"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "hide": false,
+          "rawQuery": true,
+          "rawSql": "SELECT name FROM installation WHERE id IN ('${namespace}') LIMIT 50 ",
+          "refId": "B",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [
+                  {
+                    "name": "name",
+                    "type": "functionParameter"
+                  }
+                ],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50,
+            "whereJsonTree": {
+              "children1": [
+                {
+                  "id": "a89aabba-cdef-4012-b456-718cfa4edce2",
+                  "properties": {
+                    "field": "id",
+                    "fieldSrc": "field",
+                    "operator": "select_any_in",
+                    "value": [
+                      "$namespace"
+                    ],
+                    "valueSrc": [
+                      "value"
+                    ],
+                    "valueType": [
+                      "text"
+                    ]
+                  },
+                  "type": "rule"
+                }
+              ],
+              "id": "a88bb99b-89ab-4cde-b012-318cfa4e3aee",
+              "type": "group"
+            },
+            "whereString": "id IN ('$namespace')"
+          },
+          "table": "installation"
+        }
+      ],
+      "title": "Instance Name",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 50,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.3.3",
+      "type": "text"
     },
     {
       "datasource": {
@@ -104,7 +300,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -112,7 +309,7 @@
         "h": 4,
         "w": 5,
         "x": 0,
-        "y": 1
+        "y": 5
       },
       "id": 3,
       "options": {
@@ -127,10 +324,11 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.2.2",
+      "pluginVersion": "10.3.3",
       "targets": [
         {
           "datasource": {
@@ -138,7 +336,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(msteams_connect_app_connected_users{namespace=~\"$namespace\"})",
+          "expr": "max(msteams_connect_app_connected_users{namespace=~\"$namespace\"})",
           "instant": false,
           "legendFormat": "Connected Users",
           "range": true,
@@ -153,7 +351,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "The total number of synthetic users.",
+      "description": "The maximum number of Mattermost users allowed to connect to MS Teams.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -168,17 +366,18 @@
                 "value": null
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 5,
+        "w": 4,
         "x": 5,
-        "y": 1
+        "y": 5
       },
-      "id": 4,
+      "id": 58,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -191,10 +390,11 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.2.2",
+      "pluginVersion": "10.3.3",
       "targets": [
         {
           "datasource": {
@@ -202,14 +402,14 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(msteams_connect_app_synthetic_users{namespace=~\"$namespace\"})",
+          "expr": "max(msteams_connect_app_whitelist_limit{namespace=~\"$namespace\"})",
           "instant": false,
-          "legendFormat": "Synthetic Users",
+          "legendFormat": "Connected Users",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Synthetic Users",
+      "title": "Whitelist Limit",
       "type": "stat"
     },
     {
@@ -236,15 +436,16 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
         "w": 5,
-        "x": 10,
-        "y": 1
+        "x": 9,
+        "y": 5
       },
       "id": 5,
       "options": {
@@ -259,10 +460,11 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.2.2",
+      "pluginVersion": "10.3.3",
       "targets": [
         {
           "datasource": {
@@ -270,7 +472,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(msteams_connect_app_linked_channels{namespace=~\"$namespace\"})",
+          "expr": "max(msteams_connect_app_linked_channels{namespace=~\"$namespace\"})",
           "instant": false,
           "legendFormat": "Linked Channels",
           "range": true,
@@ -295,9 +497,152 @@
             {
               "options": {
                 "0": {
-                  "color": "red",
+                  "color": "yellow",
                   "index": 0,
                   "text": "Sync job offline"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 14,
+        "y": 5
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max(msteams_connect_app_upstream_users{namespace=~\"$namespace\"})",
+          "instant": false,
+          "legendFormat": "Linked Channels",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "MS Teams Users",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The total number of synthetic users.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max(msteams_connect_app_synthetic_users{namespace=~\"$namespace\"})",
+          "instant": false,
+          "legendFormat": "Synthetic Users",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Synthetic Users",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "2": {
+                  "color": "yellow",
+                  "index": 0,
+                  "text": "<=1.5.3"
                 }
               },
               "type": "value"
@@ -315,17 +660,18 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 5,
-        "x": 15,
-        "y": 1
+        "w": 8,
+        "x": 0,
+        "y": 9
       },
-      "id": 21,
+      "id": 54,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -338,10 +684,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto",
+        "showPercentChange": false,
+        "textMode": "name",
         "wideLayout": true
       },
-      "pluginVersion": "10.2.2",
+      "pluginVersion": "10.3.3",
       "targets": [
         {
           "datasource": {
@@ -349,14 +696,82 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(msteams_connect_app_upstream_users{namespace=~\"$namespace\"})",
+          "exemplar": false,
+          "expr": "msteams_connect_system_plugin_info{namespace=~\"$namespace\",plugin=\"msteams\"} OR on() label_replace(vector(2), \"version\", \"<=1.5.3\", \"\", \"\")\n",
           "instant": false,
-          "legendFormat": "Linked Channels",
+          "legendFormat": "{{version}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "MS Teams Users",
+      "title": "Plugin Versions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "When the application client secret expires.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeAsIso",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "id": 60,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^Expiry Timestamp$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P3497915E6DC419FB"
+          },
+          "editorMode": "code",
+          "expr": "min(msteams_connect_msgraph_client_secret_end_date_timestamp_seconds{namespace=~\"$namespace\",plugin=\"msteams\"}  * 1000)",
+          "instant": false,
+          "legendFormat": "Expiry Timestamp",
+          "range": true,
+          "refId": "Expiry Timestamp"
+        }
+      ],
+      "title": "Client Secret Expiry",
       "type": "stat"
     },
     {
@@ -369,55 +784,36 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "red",
-                  "index": 0,
-                  "text": "Offline"
-                },
-                "1": {
-                  "color": "green",
-                  "index": 1,
-                  "text": "Online"
-                }
-              },
-              "type": "value"
-            },
-            {
-              "options": {
-                "from": 0,
-                "result": {
-                  "color": "yellow",
-                  "index": 2,
-                  "text": "Degraded"
-                },
-                "to": 1
-              },
-              "type": "range"
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "red",
                 "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.95
+              },
+              {
+                "color": "green",
+                "value": 0.99
               }
             ]
           },
-          "unit": "bool_on_off"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 1
+        "w": 8,
+        "x": 16,
+        "y": 9
       },
-      "id": 20,
+      "id": 45,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -430,26 +826,26 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.2.2",
+      "pluginVersion": "10.3.3",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "P27C405C01959D762"
           },
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg(up{namespace=~\"$namespace\", endpoint=\"msteamsmetrics\"})",
+          "expr": "1-(sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\",success!=\"true\"}[5m])) / sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\"}[5m])) or vector(0))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Metrics",
+      "title": "Client Success Rate",
       "type": "stat"
     },
     {
@@ -458,7 +854,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 13
       },
       "id": 39,
       "panels": [],
@@ -520,7 +916,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": [
           {
@@ -541,6 +938,21 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last Week"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#404040",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },
@@ -548,7 +960,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 6
+        "y": 14
       },
       "id": 12,
       "options": {
@@ -570,7 +982,21 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\"}[5m] offset 7d)) ",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Last Week",
+          "range": true,
+          "refId": "Last Week"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
           "expr": "sum(rate(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\"}[5m])) by (instance)",
+          "hide": false,
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true,
@@ -588,6 +1014,32 @@
           "legendFormat": "Total",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_db_store_time_count{namespace=\"$namespace\"}[5m])) by (instance)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{instance [Legacy]}}",
+          "range": true,
+          "refId": "A (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_db_store_time_count{namespace=\"$namespace\"}[5m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total [Legacy]",
+          "range": true,
+          "refId": "B (Legacy)"
         }
       ],
       "title": "DB Calls (per second)",
@@ -661,47 +1113,14 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": [
           {
             "matcher": {
               "id": "byRegexp",
-              "options": "/Error/"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "thresholds"
-                }
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "yellow",
-                      "value": 5
-                    },
-                    {
-                      "color": "red",
-                      "value": 10
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "/Requests \\(Total\\)/"
+              "options": "/Total/"
             },
             "properties": [
               {
@@ -716,6 +1135,21 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/Last Week/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#404040",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },
@@ -723,7 +1157,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 6
+        "y": 14
       },
       "id": 1,
       "options": {
@@ -745,9 +1179,22 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_http_requests_total{namespace=~\"$namespace\"}[5m] offset 7d))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Last Week",
+          "range": true,
+          "refId": "Last Week"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
           "expr": "rate(msteams_connect_http_requests_total{namespace=~\"$namespace\"}[5m])",
           "instant": false,
-          "legendFormat": "Requests ({{instance}})",
+          "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
         },
@@ -760,35 +1207,9 @@
           "expr": "sum(rate(msteams_connect_http_requests_total{namespace=~\"$namespace\"}[5m]))",
           "hide": false,
           "instant": false,
-          "legendFormat": "Requests (Total)",
+          "legendFormat": "Total",
           "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "rate(msteams_connect_http_errors_total{namespace=~\"$namespace\"}[5m])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Errors ({{instance}})",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_http_errors_total{namespace=~\"$namespace\"}[5m]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Errors (Total)",
-          "range": true,
-          "refId": "D"
+          "refId": "Total"
         }
       ],
       "title": "HTTP Requests (per second)",
@@ -864,7 +1285,8 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "s",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -872,7 +1294,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 22
       },
       "id": 13,
       "options": {
@@ -912,6 +1334,32 @@
           "legendFormat": "p50 ({{instance}})",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(msteams_connect_db_store_time_bucket{namespace=\"$namespace\"}[5m])) by (instance,le))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "p99 ({{instance}}) [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(msteams_connect_db_store_time_bucket{namespace=\"$namespace\"}[5m])) by (instance,le))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "p50 ({{instance}}) [Legacy]",
+          "range": true,
+          "refId": "B (Legacy)"
         }
       ],
       "title": "DB Latency",
@@ -987,7 +1435,8 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "s",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -995,7 +1444,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 14
+        "y": 22
       },
       "id": 6,
       "options": {
@@ -1035,6 +1484,32 @@
           "legendFormat": "p50 ({{instance}})",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(msteams_connect_api_time_bucket{namespace=~\"$namespace\"}[5m])) by (instance,le))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "p99 ({{instance}}) [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(msteams_connect_api_time_bucket{namespace=~\"$namespace\"}[5m])) by (instance,le))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "p50 ({{instance}}) [Legacy]",
+          "range": true,
+          "refId": "B (Legacy)"
         }
       ],
       "title": "API Latency",
@@ -1110,7 +1585,8 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1118,7 +1594,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 23
+        "y": 31
       },
       "id": 14,
       "options": {
@@ -1145,6 +1621,19 @@
           "legendFormat": "{{method}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(msteams_connect_db_store_time_count{namespace=\"$namespace\"}[5m])) by (method)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{method}} [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
         }
       ],
       "title": "DB Calls by Count",
@@ -1220,15 +1709,31 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "unitScale": true
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last Week"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 23
+        "y": 31
       },
       "id": 7,
       "options": {
@@ -1255,6 +1760,19 @@
           "legendFormat": "{{handler}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(msteams_connect_api_time_count{namespace=~\"$namespace\"}[5m])) by (handler)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{handler}} [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
         }
       ],
       "title": "API Requests by Count",
@@ -1321,7 +1839,8 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "s",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1329,7 +1848,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 40
       },
       "id": 15,
       "options": {
@@ -1360,6 +1879,19 @@
           "legendFormat": "{{method}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(msteams_connect_db_store_time_sum{namespace=\"$namespace\"}[5m])) by (method) / sum(increase(msteams_connect_db_store_time_count{namespace=\"$namespace\"}[5m])) by (method)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{method}} [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
         }
       ],
       "title": "DB calls by Duration",
@@ -1435,7 +1967,8 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "s",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1443,7 +1976,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 40
       },
       "id": 8,
       "options": {
@@ -1474,9 +2007,291 @@
           "legendFormat": "{{handler}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(msteams_connect_api_time_sum{namespace=~\"$namespace\"}[5m])) by (handler) / sum(increase(msteams_connect_api_time_count{namespace=~\"$namespace\"}[5m])) by (handler)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{handler}} [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
         }
       ],
       "title": "API Requests by Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 49,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_system_plugin_goroutine_failures_total{namespace=\"$namespace\"}[5m])) by (instance) ",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutine Failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "#EAB839",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/Requests \\(Total\\)/"
+            },
+            "properties": [
+              {
+                "id": "custom.fillOpacity",
+                "value": 10
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#808080",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "Last Week"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#404040",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 59,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(msteams_connect_http_errors_total{namespace=~\"$namespace\"}[5m])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_http_errors_total{namespace=~\"$namespace\"}[5m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_http_errors_total{namespace=~\"$namespace\"}[5m] offset 7d))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Last Week",
+          "range": true,
+          "refId": "Last Week (Errors)"
+        }
+      ],
+      "title": "HTTP Errors (per second)",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(.*):9094\\)",
+            "renamePattern": "$1)"
+          }
+        }
+      ],
       "type": "timeseries"
     },
     {
@@ -1485,7 +2300,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 58
       },
       "id": 38,
       "panels": [],
@@ -1543,8 +2358,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1552,7 +2366,8 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "unitScale": true
         },
         "overrides": [
           {
@@ -1573,6 +2388,21 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last Week"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#404040",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },
@@ -1580,7 +2410,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 42
+        "y": 59
       },
       "id": 40,
       "options": {
@@ -1602,11 +2432,12 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\",success=\"true\"}[5m])) by (instance)",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\"}[5m] offset 7d))",
+          "hide": false,
           "instant": false,
-          "legendFormat": "Requests ({{instance}})",
+          "legendFormat": "Last Week",
           "range": true,
-          "refId": "A"
+          "refId": "Last Week"
         },
         {
           "datasource": {
@@ -1614,12 +2445,11 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\",success!=\"true\"}[5m])) by (instance)",
-          "hide": false,
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\"}[5m])) by (instance)",
           "instant": false,
-          "legendFormat": "Errors ({{instance}})",
+          "legendFormat": "Requests ({{instance}})",
           "range": true,
-          "refId": "B"
+          "refId": "A"
         },
         {
           "datasource": {
@@ -1633,6 +2463,32 @@
           "legendFormat": "Total",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\"}[5m])) by (instance)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Requests ({{instance}}) [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\"}[5m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total [Legacy]",
+          "range": true,
+          "refId": "C (Legacy)"
         }
       ],
       "title": "MS Graph Client Requests",
@@ -1656,7 +2512,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "thresholds"
           },
           "custom": {
             "axisBorderShow": false,
@@ -1698,16 +2554,20 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 1
               },
               {
                 "color": "red",
-                "value": 80
+                "value": 10
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "unitScale": true
         },
         "overrides": [
           {
@@ -1728,6 +2588,21 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last Week"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#404040",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },
@@ -1735,7 +2610,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 59
       },
       "id": 41,
       "options": {
@@ -1776,6 +2651,45 @@
           "legendFormat": "Total",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\",success!=\"true\"}[5m])) by (instance)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Errors ({{instance}}) [Legacy]",
+          "range": true,
+          "refId": "B (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\",success!=\"true\"}[5m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total [Legacy]",
+          "range": true,
+          "refId": "C (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\",success!=\"true\"}[5m] offset 7d))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Last Week",
+          "range": true,
+          "refId": "Last Week"
         }
       ],
       "title": "MS Graph Client Requests (Errors Only)",
@@ -1850,7 +2764,8 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1858,7 +2773,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 51
+        "y": 68
       },
       "id": 23,
       "options": {
@@ -1882,9 +2797,22 @@
           "editorMode": "code",
           "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\",method=~\"$top_msgraph_client_count\"}[5m])) by (method)",
           "instant": false,
-          "legendFormat": "{{handler}}",
+          "legendFormat": "{{method}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\"}[5m])) by (method)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{method}} [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
         }
       ],
       "title": "MS Graph Client Requests by Count",
@@ -1959,7 +2887,8 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "s",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1967,7 +2896,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 68
       },
       "id": 22,
       "options": {
@@ -2007,6 +2936,32 @@
           "legendFormat": "p50 ({{instance}})",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(msteams_connect_msgraph_client_time_bucket{namespace=~\"$namespace\"}[5m])) by (instance,le))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "p99 ({{instance}}) [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(msteams_connect_msgraph_client_time_bucket{namespace=~\"$namespace\"}[5m])) by (instance,le))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "p50 ({{instance}}) [Legacy]",
+          "range": true,
+          "refId": "B (Legacy)"
         }
       ],
       "title": "MS Graph Client Latency",
@@ -2081,7 +3036,8 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "s",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -2089,7 +3045,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 60
+        "y": 77
       },
       "id": 24,
       "options": {
@@ -2137,24 +3093,112 @@
       "type": "timeseries"
     },
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 69
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
-      "id": 26,
-      "panels": [],
-      "title": "Events",
-      "type": "row"
+      "description": "Percentage of client requests failing.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 77
+      },
+      "id": 53,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P27C405C01959D762"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\",success!=\"true\"}[5m])) / sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\"}[5m])) or vector(0)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "MS Graph Client Error Rate",
+      "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "The number of events currently in the change event queue and awaiting processing by an available goroutine.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2204,15 +3248,156 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 86
+      },
+      "id": 57,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P3497915E6DC419FB"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(msteams_connect_msgraph_oauth_token_invalidated_total{namespace=\"$namespace\"}[5m]))",
+          "instant": false,
+          "legendFormat": "Invalidated Tokens",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Invalidated oAuth Tokens",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
         "w": 24,
         "x": 0,
-        "y": 70
+        "y": 94
+      },
+      "id": 26,
+      "panels": [],
+      "title": "Events",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The number of events currently in the change event queue and awaiting processing by an available goroutine, as well as the number of events rejected because the queue was full.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/Rejected/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds",
+                  "seriesBy": "last"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 95
       },
       "id": 25,
       "options": {
@@ -2238,9 +3423,22 @@
           "expr": "sum(increase(msteams_connect_app_change_event_queue_length{namespace=\"$namespace\"}[5m])) by (instance)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "Length {{instance}}",
           "range": true,
-          "refId": "B"
+          "refId": "Length"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(msteams_connect_events_change_event_queue_rejected_total{namespace=\"$namespace\"}[5m])) by (instance)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Rejected {{instance}}",
+          "range": true,
+          "refId": "Rejected"
         }
       ],
       "title": "Change Event Queue",
@@ -2310,7 +3508,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -2318,7 +3517,7 @@
         "h": 8,
         "w": 10,
         "x": 0,
-        "y": 78
+        "y": 103
       },
       "id": 27,
       "options": {
@@ -2345,6 +3544,19 @@
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_processed_change_event_total{namespace=\"$namespace\",discarded_reason=\"\"}[5m])) by (change_type)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{change_type}} [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
         }
       ],
       "title": "Processed Change Events (per second)",
@@ -2405,7 +3617,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -2413,7 +3626,7 @@
         "h": 8,
         "w": 9,
         "x": 10,
-        "y": 78
+        "y": 103
       },
       "id": 28,
       "options": {
@@ -2440,6 +3653,19 @@
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_processed_change_event_total{namespace=\"$namespace\",discarded_reason!=\"\"}[5m])) by (discarded_reason)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{discarded_reason}} [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
         }
       ],
       "title": "Discarded Change Events (per second)",
@@ -2490,7 +3716,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -2498,7 +3725,7 @@
         "h": 8,
         "w": 5,
         "x": 19,
-        "y": 78
+        "y": 103
       },
       "id": 42,
       "options": {
@@ -2513,10 +3740,11 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.2.2",
+      "pluginVersion": "10.3.3",
       "targets": [
         {
           "datasource": {
@@ -2589,7 +3817,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -2597,7 +3826,7 @@
         "h": 8,
         "w": 10,
         "x": 0,
-        "y": 86
+        "y": 111
       },
       "id": 29,
       "options": {
@@ -2624,6 +3853,19 @@
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_lifecycle_event_total{namespace=\"$namespace\"}[5m])) by (event_type)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{event_type}} [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
         }
       ],
       "title": "Processed Lifecycle Events (per second)",
@@ -2684,7 +3926,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -2692,7 +3935,7 @@
         "h": 8,
         "w": 9,
         "x": 10,
-        "y": 86
+        "y": 111
       },
       "id": 30,
       "options": {
@@ -2769,7 +4012,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -2777,7 +4021,7 @@
         "h": 8,
         "w": 5,
         "x": 19,
-        "y": 86
+        "y": 111
       },
       "id": 43,
       "options": {
@@ -2792,10 +4036,11 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.2.2",
+      "pluginVersion": "10.3.3",
       "targets": [
         {
           "datasource": {
@@ -2868,7 +4113,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -2876,7 +4122,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 94
+        "y": 119
       },
       "id": 37,
       "options": {
@@ -2903,6 +4149,19 @@
           "legendFormat": "{{action}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_subscriptions_count{namespace=\"$namespace\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{action}} [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
         }
       ],
       "title": "Subscriptions (per second)",
@@ -2963,7 +4222,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -2971,7 +4231,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 102
+        "y": 127
       },
       "id": 31,
       "options": {
@@ -3024,6 +4284,45 @@
           "legendFormat": "Total ({{action}})",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_messages_count{namespace=\"$namespace\",source=\"mattermost\",is_direct=\"true\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Direct ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_messages_count{namespace=\"$namespace\",source=\"mattermost\",is_direct!=\"true\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Channel ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "B (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_messages_count{namespace=\"$namespace\",source=\"mattermost\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "C (Legacy)"
         }
       ],
       "title": "Messages (Mattermost -> MSTeams, per second)",
@@ -3084,7 +4383,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -3092,7 +4392,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 102
+        "y": 127
       },
       "id": 32,
       "options": {
@@ -3145,6 +4445,45 @@
           "legendFormat": "Total ({{action}})",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_messages_count{namespace=\"$namespace\",source=\"msteams\",is_direct=\"true\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Direct ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_messages_count{namespace=\"$namespace\",source=\"msteams\",is_direct!=\"true\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Channel ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "B (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_messages_count{namespace=\"$namespace\",source=\"msteams\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "C (Legacy)"
         }
       ],
       "title": "Messages (MSTeams -> Mattermost, per second)",
@@ -3205,7 +4544,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -3213,7 +4553,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 110
+        "y": 135
       },
       "id": 33,
       "options": {
@@ -3265,6 +4605,45 @@
           "legendFormat": "Total ({{action}})",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_reactions_count{namespace=\"$namespace\",source=\"mattermost\",is_direct=\"true\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Direct ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_reactions_count{namespace=\"$namespace\",source=\"mattermost\",is_direct!=\"true\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Channel ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "B (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_reactions_count{namespace=\"$namespace\",source=\"mattermost\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "C (Legacy)"
         }
       ],
       "title": "Reactions (Mattermost -> MSTeams, per second)",
@@ -3325,7 +4704,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -3333,7 +4713,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 110
+        "y": 135
       },
       "id": 34,
       "options": {
@@ -3386,6 +4766,45 @@
           "legendFormat": "Total ({{action}})",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_reactions_count{namespace=\"$namespace\",source=\"msteams\",is_direct=\"true\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Direct ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_reactions_count{namespace=\"$namespace\",source=\"msteams\",is_direct!=\"true\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Channel ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "B (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_reactions_count{namespace=\"$namespace\",source=\"msteams\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "C (Legacy)"
         }
       ],
       "title": "Reactions (MSTeams -> Mattermost, per second)",
@@ -3446,7 +4865,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -3454,7 +4874,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 118
+        "y": 143
       },
       "id": 35,
       "options": {
@@ -3507,6 +4927,45 @@
           "legendFormat": "Total ({{action}})",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_files_count{namespace=\"$namespace\",source=\"mattermost\",is_direct=\"true\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Direct ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_files_count{namespace=\"$namespace\",source=\"mattermost\",is_direct!=\"true\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Channel ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "B (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_files_count{namespace=\"$namespace\",source=\"mattermost\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "C (Legacy)"
         }
       ],
       "title": "Files (Mattermost -> MSTeams, per second)",
@@ -3567,7 +5026,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -3575,7 +5035,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 118
+        "y": 143
       },
       "id": 36,
       "options": {
@@ -3628,6 +5088,45 @@
           "legendFormat": "Total ({{action}})",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_files_count{namespace=\"$namespace\",source=\"msteams\",is_direct=\"true\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Direct ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "A (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_files_count{namespace=\"$namespace\",source=\"msteams\",is_direct!=\"true\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Channel ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "B (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_files_count{namespace=\"$namespace\",source=\"msteams\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total ({{action}}) [Legacy]",
+          "range": true,
+          "refId": "C (Legacy)"
         }
       ],
       "title": "Files (MSTeams -> Mattermost, per second)",
@@ -3639,7 +5138,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 126
+        "y": 151
       },
       "id": 17,
       "panels": [],
@@ -3705,7 +5204,8 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -3713,7 +5213,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 127
+        "y": 152
       },
       "id": 18,
       "options": {
@@ -3804,7 +5304,8 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "s",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -3812,7 +5313,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 127
+        "y": 152
       },
       "id": 19,
       "options": {
@@ -3856,7 +5357,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 135
+        "y": 160
       },
       "id": 10,
       "panels": [],
@@ -3917,7 +5418,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": [
           {
@@ -3938,7 +5440,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 136
+        "y": 161
       },
       "id": 11,
       "options": {
@@ -3960,7 +5462,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "go_goroutines{namespace=~\"$namespace\",instance=~\".*:9094\"}",
+          "expr": "go_goroutines{namespace=~\"$namespace\",plugin=\"msteams\"}",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true,
@@ -3972,12 +5474,38 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(go_goroutines{namespace=~\"$namespace\",instance=~\".*:9094\"})",
+          "expr": "sum(go_goroutines{namespace=~\"$namespace\",plugin=\"msteams\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "Total",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "go_goroutines{namespace=~\"$namespace\",endpoint=\"msteamsmetrics\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A (Legacy)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(go_goroutines{namespace=~\"$namespace\",endpoint=\"msteamsmetrics\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B (Legacy)"
         }
       ],
       "title": "Goroutines",
@@ -4047,7 +5575,8 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "decbytes",
+          "unitScale": true
         },
         "overrides": [
           {
@@ -4068,7 +5597,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 136
+        "y": 161
       },
       "id": 16,
       "options": {
@@ -4090,11 +5619,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "go_memstats_heap_inuse_bytes{namespace=~\"$namespace\",instance=~\".*:9094\"}",
+          "expr": "go_memstats_heap_inuse_bytes{namespace=~\"$namespace\",plugin=\"msteams\"}",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "go_memstats_heap_inuse_bytes{namespace=~\"$namespace\",endpoint=\"msteamsmetrics\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A (Legacy)"
         }
       ],
       "title": "Heap Utilization",
@@ -4108,11 +5650,377 @@
         }
       ],
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 169
+      },
+      "id": 55,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P27C405C01959D762"
+          },
+          "editorMode": "code",
+          "expr": "sum(msteams_connect_app_active_workers_total) by (worker)",
+          "instant": false,
+          "legendFormat": "{{worker}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Workers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 169
+      },
+      "id": 56,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P27C405C01959D762"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(msteams_connect_app_workers_time_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (worker,le))",
+          "instant": false,
+          "legendFormat": "{{worker}}, p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P27C405C01959D762"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(msteams_connect_app_workers_time_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (worker,le))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{worker}}, p50",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Workers Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 177
+      },
+      "id": 61,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(mattermost_db_master_connections_total{namespace=\"${namespace}\"})",
+          "interval": "",
+          "legendFormat": "master",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(mattermost_db_read_replica_connections_total{namespace=\"${namespace}\"})",
+          "interval": "",
+          "legendFormat": "replica",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "DB Connections (Whole Server)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 185
+      },
+      "id": 51,
+      "panels": [],
+      "title": "Logs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "PFDB45C165C6355FF"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 186
+      },
+      "id": 52,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "PFDB45C165C6355FF"
+          },
+          "editorMode": "code",
+          "expr": "{namespace=\"$namespace\"} | json | plugin_id=\"com.mattermost.msteams-sync\" | level=\"error\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Logs",
+      "type": "logs"
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 38,
-  "tags": [],
+  "schemaVersion": 39,
+  "tags": [
+    "mattermost",
+    "msteams"
+  ],
   "templating": {
     "list": [
       {
@@ -4351,8 +6259,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "MSTeams Connect (v2, Renamed Metrics)",
+  "title": "MS Teams (By Instance)",
   "uid": "c97b2768-e8bd-42fb-92e4-ad26dbf943db",
-  "version": 8,
+  "version": 54,
   "weekStart": ""
 }


### PR DESCRIPTION
#### Summary
Update the snapshot of the Cloud dashboard we use for monitoring this plugin. Note that this remains architected towards our Mattermost Cloud environment, with a `$namespace` filter and various datasource variables. Nevertheless, it's a good starting point for building a single-installation version, and a future iteration may find a way to make the `$namespace` parameter optional

#### Ticket Link
None.