### PR TITLE
MM-57367: log when invite sent

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -341,10 +341,10 @@ func (a *API) connect(w http.ResponseWriter, r *http.Request) {
 func (a *API) notifyConnect(w http.ResponseWriter, r *http.Request) {
 	userID := r.Header.Get("Mattermost-User-ID")
 
-	if inviteWasSent, err := a.p.MaybeSendInviteMessage(userID); inviteWasSent {
-		a.p.API.LogInfo("Successfully sent connection invite", "user_id", userID)
-	} else if err != nil {
+	if inviteWasSent, err := a.p.MaybeSendInviteMessage(userID); err != nil {
 		a.p.API.LogWarn("Error in connection invite flow", "user_id", userID, "error", err.Error())
+	} else if inviteWasSent {
+		a.p.API.LogInfo("Successfully sent connection invite", "user_id", userID)
 	}
 }
 

--- a/server/api.go
+++ b/server/api.go
@@ -341,7 +341,9 @@ func (a *API) connect(w http.ResponseWriter, r *http.Request) {
 func (a *API) notifyConnect(w http.ResponseWriter, r *http.Request) {
 	userID := r.Header.Get("Mattermost-User-ID")
 
-	if _, err := a.p.MaybeSendInviteMessage(userID); err != nil {
+	if inviteWasSent, err := a.p.MaybeSendInviteMessage(userID); inviteWasSent {
+		a.p.API.LogInfo("Successfully sent connection invite", "user_id", userID)
+	} else if err != nil {
 		a.p.API.LogWarn("Error in connection invite flow", "user_id", userID, "error", err.Error())
 	}
 }

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -99,6 +99,11 @@ export default class Plugin {
 
     uninitialize() {
         this.removeStoreSubscription?.();
+
+        if (this.activityFunc) {
+            document.removeEventListener('click', this.activityFunc);
+            delete this.activityFunc;
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
- Log when connection invite successfully sent. 
- Also adds `clean up activity handler` during `uninitialize` that was missing in #544.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-57367
