### PR TITLE
[MM-56867] Fix metrics by not counting disabled users

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -636,7 +636,7 @@ func (p *Plugin) syncUsers() {
 
 	configuration := p.getConfiguration()
 	syncGuestUsers := configuration.SyncGuestUsers
-	var activeMSTeamsUsersCount int64 = 0
+	var activeMSTeamsUsersCount int64
 	for _, msUser := range msUsers {
 		if msUser.IsAccountEnabled {
 			activeMSTeamsUsersCount++

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -636,10 +636,10 @@ func (p *Plugin) syncUsers() {
 
 	configuration := p.getConfiguration()
 	syncGuestUsers := configuration.SyncGuestUsers
-	var activeMSUsersCount int64 = 0
+	var activeMSTeamsUsersCount int64 = 0
 	for _, msUser := range msUsers {
 		if msUser.IsAccountEnabled {
-			activeMSUsersCount++
+			activeMSTeamsUsersCount++
 		}
 
 		userSuffixID := 1
@@ -814,7 +814,7 @@ func (p *Plugin) syncUsers() {
 			}
 		}
 	}
-	p.GetMetrics().ObserveUpstreamUsers(activeMSUsersCount)
+	p.GetMetrics().ObserveUpstreamUsers(activeMSTeamsUsersCount)
 }
 
 func generateSecret() (string, error) {

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -281,9 +281,10 @@ func TestSyncUsers(t *testing.T) {
 			SetupClient: func(client *mocks.Client) {
 				client.On("ListUsers").Return([]clientmodels.User{
 					{
-						ID:          testutils.GetTeamsUserID(),
-						DisplayName: "mockDisplayName",
-						Mail:        "mockEmail@msteams.com",
+						ID:               testutils.GetTeamsUserID(),
+						DisplayName:      "mockDisplayName",
+						Mail:             "mockEmail@msteams.com",
+						IsAccountEnabled: true,
 					},
 				}, nil).Times(1)
 			},
@@ -312,9 +313,10 @@ func TestSyncUsers(t *testing.T) {
 			SetupClient: func(client *mocks.Client) {
 				client.On("ListUsers").Return([]clientmodels.User{
 					{
-						ID:          testutils.GetTeamsUserID(),
-						DisplayName: "mockDisplayName",
-						Mail:        "mockEmail@msteams.com",
+						ID:               testutils.GetTeamsUserID(),
+						DisplayName:      "mockDisplayName",
+						Mail:             "mockEmail@msteams.com",
+						IsAccountEnabled: true,
 					},
 				}, nil).Times(1)
 			},
@@ -347,9 +349,10 @@ func TestSyncUsers(t *testing.T) {
 			SetupClient: func(client *mocks.Client) {
 				client.On("ListUsers").Return([]clientmodels.User{
 					{
-						ID:          testutils.GetTeamsUserID(),
-						DisplayName: "mockDisplayName",
-						Mail:        "mockEmail@msteams.com",
+						ID:               testutils.GetTeamsUserID(),
+						DisplayName:      "mockDisplayName",
+						Mail:             "mockEmail@msteams.com",
+						IsAccountEnabled: true,
 					},
 				}, nil).Times(1)
 			},


### PR DESCRIPTION
#### Summary
- [x] `msteams_connect_app_upstream_users` also counts MSTeams accounts that are not enabled. This PR fixes this

#### Ticket Link
Partially fixes https://mattermost.atlassian.net/browse/MM-56887

