### PR TITLE
[MM-56982] UNIQUE index on msteamsuserid 

### DIFF
--- a/server/store/sqlstore/helper_test.go
+++ b/server/store/sqlstore/helper_test.go
@@ -83,13 +83,13 @@ func setupTestStore(t *testing.T) (*SQLStore, *plugintest.API) {
 	store.api = api
 	store.db = db
 
-	err := store.Init("")
-	require.NoError(t, err)
-	err = store.createTable("Teams", "Id VARCHAR(255), DisplayName VARCHAR(255)")
+	err := store.createTable("Teams", "Id VARCHAR(255), DisplayName VARCHAR(255)")
 	require.NoError(t, err)
 	err = store.createTable("Channels", "Id VARCHAR(255), DisplayName VARCHAR(255)")
 	require.NoError(t, err)
-	err = store.createTable("Users", "Id VARCHAR(255), FirstName VARCHAR(255), LastName VARCHAR(255), Email VARCHAR(255)")
+	err = store.createTable("Users", "Id VARCHAR(255), FirstName VARCHAR(255), LastName VARCHAR(255), Email VARCHAR(255), remoteid VARCHAR(26), createat BIGINT")
+	require.NoError(t, err)
+	err = store.Init("")
 	require.NoError(t, err)
 
 	return store, api

--- a/server/store/sqlstore/migrations.go
+++ b/server/store/sqlstore/migrations.go
@@ -164,6 +164,6 @@ func (s *SQLStore) addPrimaryKey(tableName, columnList string) error {
 	return nil
 }
 
-func (s *SQLStore) createMSTeamsUserIdUniqueIndex() error {
+func (s *SQLStore) createMSTeamsUserIDUniqueIndex() error {
 	return s.createUniqueIndex(usersTableName, "idx_msteamssync_users_msteamsuserid_unq", "msteamsuserid")
 }

--- a/server/store/sqlstore/migrations.go
+++ b/server/store/sqlstore/migrations.go
@@ -25,9 +25,9 @@ const (
 func (s *SQLStore) runMSTeamUserIDDedup() error {
 	// get all users with duplicate msteamsuserid
 	rows, err := s.getQueryBuilder().Select(
-		usersTableName+".mmuserid",
-		usersTableName+".msteamsuserid",
-		"users.remoteid",
+		"mmuserid",
+		"msteamsuserid",
+		"remoteid",
 	).
 		From(usersTableName).
 		Where(sq.Expr("msteamsuserid IN ( SELECT msteamsuserid FROM " + usersTableName + " GROUP BY msteamsuserid HAVING COUNT(*) > 1)")).

--- a/server/store/sqlstore/migrations.go
+++ b/server/store/sqlstore/migrations.go
@@ -1,6 +1,10 @@
 package sqlstore
 
 import (
+	"context"
+	"database/sql"
+	"fmt"
+
 	sq "github.com/Masterminds/squirrel"
 )
 
@@ -12,4 +16,82 @@ func (s *SQLStore) runMigrationRemoteID(remoteID string) error {
 		sq.Like{"Username": "msteams_%"},
 	}).Exec()
 	return err
+}
+
+const (
+	DedupScoreDefault      byte = 0
+	DedupScoreNotSynthetic byte = 1
+)
+
+func (s *SQLStore) runMSTeamUserIDDedup() error {
+	rows, err := s.getQueryBuilder().Select(
+		"msteamssync_users.mmuserid",
+		"msteamssync_users.msteamsuserid",
+		"users.username",
+		"users.remoteid",
+	).
+		From("msteamssync_users").
+		Where(sq.Expr("msteamsuserid IN ( SELECT msteamsuserid FROM msteamssync_users GROUP BY msteamsuserid HAVING COUNT(*) > 1)")).
+		Join("users ON msteamssync_users.mmuserid = users.id").
+		OrderBy("users.createat ASC").
+		Query()
+	if err != nil {
+		return err
+	}
+
+	bestCandidate := map[string]string{}
+	bestCandidateScore := map[string]byte{}
+	var mmuserid, msteamsuserid, username, remoteid string
+	var nRemoteid sql.NullString
+	for rows.Next() {
+		err := rows.Scan(&mmuserid, &msteamsuserid, &username, &nRemoteid)
+		if err != nil {
+			return err
+		}
+		s.api.LogDebug(fmt.Sprintf("mmuserid: [%s], msteamsuserid: [%s], username: [%s]", mmuserid, msteamsuserid, username))
+
+		remoteid = ""
+		if nRemoteid.Valid {
+			remoteid = nRemoteid.String
+		}
+
+		currentUserScore := DedupScoreDefault
+		if remoteid == "" {
+			currentUserScore = DedupScoreNotSynthetic
+		}
+
+		_, ok := bestCandidate[msteamsuserid]
+		if !ok {
+			bestCandidate[msteamsuserid] = mmuserid
+			bestCandidateScore[msteamsuserid] = currentUserScore
+			continue
+		}
+
+		if ok && currentUserScore > bestCandidateScore[msteamsuserid] {
+			bestCandidate[msteamsuserid] = mmuserid
+			bestCandidateScore[msteamsuserid] = currentUserScore
+			continue
+		}
+	}
+
+	// for each msteamsusers, remove all but the best candidate
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for msteamsuserid, mmuserid := range bestCandidate {
+		s.api.LogInfo("Deleting duplicates for msteamsuserid: " + msteamsuserid + ", keeping mmuserid: " + mmuserid)
+		_, err := s.getQueryBuilderWithRunner(tx).Delete("msteamssync_users").
+			Where(sq.And{
+				sq.Eq{"msteamsuserid": msteamsuserid},
+				sq.NotEq{"mmuserid": mmuserid},
+			}).
+			Exec()
+		if err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
 }

--- a/server/store/sqlstore/migrations_test.go
+++ b/server/store/sqlstore/migrations_test.go
@@ -1,0 +1,111 @@
+package sqlstore
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunMSTeamUserIDDedup(t *testing.T) {
+	store, api := setupTestStore(t)
+	assert := require.New(t)
+
+	api.On("LogInfo", "Deleting duplicates").Once()
+
+	/*
+		Test matrix:
+
+		|---------|------|------------------------------------------------------|
+		| TeamsID | MMID | Comment                                              |
+		|---------|------|------------------------------------------------------|
+		| A       | 1    |                                                      |
+		| A       | 2    | < will be kept because it's not a remote user        |
+		| A       | 3    |                                                      |
+		|---------|------|------------------------------------------------------|
+		| B       | 1    | < will be kept because it was there first (createat) |
+		| B       | 3    |                                                      |
+		|---------|------|------------------------------------------------------|
+		| C       | 1    | < not part of the dedup                              |
+		|---------|------|------------------------------------------------------|
+		| A       | 1    |                                                      |
+		| B       | 2    |                                                      |
+		| C       | 3    |                                                      |
+		| D       | 4    | < not a remote user AND created first                |
+		|---------|------|------------------------------------------------------|
+	*/
+
+	userID1Remote := model.NewId()
+	userID2 := model.NewId()
+	userID3Remote := model.NewId()
+	userID4 := model.NewId()
+	teamsUserA := "A"
+	teamsUserB := "B"
+	teamsUserC := "C"
+	teamsUserD := "D"
+
+	_, err := store.db.Exec("DROP INDEX IF EXISTS idx_msteamssync_users_msteamsuserid_unq")
+	assert.NoError(err)
+	defer store.createMSTeamsUserIdUniqueIndex()
+
+	res, err := store.getQueryBuilder().Insert("users").
+		Columns("id", "createat", "remoteid").
+		Values(userID1Remote, 100, "remote-id").
+		Values(userID2, 200, "").
+		Values(userID3Remote, 300, "remote-id").
+		Values(userID4, 10, "").
+		Exec()
+	assert.NoError(err)
+	affected, err := res.RowsAffected()
+	assert.NoError(err)
+	assert.Equal(int64(4), affected)
+
+	// ms teams user 1 will have all 3 users;
+	// user1 and 3 should be removed after the dedup because user 2 is a real user
+	res, err = store.getQueryBuilder().Insert(usersTableName).Columns("mmuserid", "msteamsuserid").
+		Values(userID1Remote, teamsUserA).
+		Values(userID2, teamsUserA).
+		Values(userID3Remote, teamsUserA).
+		Values(userID1Remote, teamsUserB).
+		Values(userID3Remote, teamsUserB).
+		Values(userID1Remote, teamsUserC).
+		Values(userID1Remote, teamsUserD).
+		Values(userID2, teamsUserD).
+		Values(userID3Remote, teamsUserD).
+		Values(userID4, teamsUserD).
+		Exec()
+	assert.NoError(err)
+	affected, err = res.RowsAffected()
+	assert.NoError(err)
+	assert.Equal(int64(10), affected)
+
+	err = store.runMSTeamUserIDDedup()
+	assert.NoError(err)
+
+	rows, err := store.getQueryBuilder().Select("mmuserid", "msteamsuserid").From(usersTableName).Query()
+	assert.NoError(err)
+	var found int
+	for rows.Next() {
+		var mmUserID, teamsUserID string
+		err = rows.Scan(&mmUserID, &teamsUserID)
+		assert.NoError(err)
+
+		if teamsUserID == teamsUserA {
+			assert.Equal(userID2, mmUserID)
+			found++
+		}
+		if teamsUserID == teamsUserB {
+			assert.Equal(userID1Remote, mmUserID)
+			found++
+		}
+		if teamsUserID == teamsUserC {
+			assert.Equal(userID1Remote, mmUserID)
+			found++
+		}
+		if teamsUserID == teamsUserD {
+			assert.Equal(userID4, mmUserID)
+			found++
+		}
+	}
+	assert.Equalf(4, found, "expected 4 rows to be found, but found %d", found)
+}

--- a/server/store/sqlstore/migrations_test.go
+++ b/server/store/sqlstore/migrations_test.go
@@ -46,7 +46,7 @@ func TestRunMSTeamUserIDDedup(t *testing.T) {
 
 	_, err := store.db.Exec("DROP INDEX IF EXISTS idx_msteamssync_users_msteamsuserid_unq")
 	assert.NoError(err)
-	defer store.createMSTeamsUserIdUniqueIndex()
+	defer func() { _ = store.createMSTeamsUserIDUniqueIndex() }()
 
 	res, err := store.getQueryBuilder().Insert("users").
 		Columns("id", "createat", "remoteid").

--- a/server/store/sqlstore/store.go
+++ b/server/store/sqlstore/store.go
@@ -180,7 +180,7 @@ func (s *SQLStore) Init(remoteID string) error {
 		return err
 	}
 
-	if err := s.createUniqueIndex(usersTableName, "idx_msteamssync_users_msteamsuserid_unq", "msteamsuserid"); err != nil {
+	if err := s.createMSTeamsUserIdUniqueIndex(); err != nil {
 		return err
 	}
 
@@ -788,11 +788,7 @@ func (s *SQLStore) CheckEnabledTeamByTeamID(teamID string) bool {
 }
 
 func (s *SQLStore) getQueryBuilder() sq.StatementBuilderType {
-	return s.getQueryBuilderWithRunner(s.db)
-}
-
-func (s *SQLStore) getQueryBuilderWithRunner(r sq.BaseRunner) sq.StatementBuilderType {
-	return sq.StatementBuilder.PlaceholderFormat(sq.Dollar).RunWith(r)
+	return sq.StatementBuilder.PlaceholderFormat(sq.Dollar).RunWith(s.db)
 }
 
 func (s *SQLStore) VerifyOAuth2State(state string) error {

--- a/server/store/sqlstore/store.go
+++ b/server/store/sqlstore/store.go
@@ -128,7 +128,7 @@ func (s *SQLStore) Init(remoteID string) error {
 			return err
 		}
 
-		if err := s.createMSTeamsUserIdUniqueIndex(); err != nil {
+		if err := s.createMSTeamsUserIDUniqueIndex(); err != nil {
 			return err
 		}
 	}

--- a/server/store/sqlstore/store.go
+++ b/server/store/sqlstore/store.go
@@ -51,63 +51,6 @@ func New(db *sql.DB, api plugin.API, enabledTeams func() []string, encryptionKey
 	}
 }
 
-func (s *SQLStore) createTable(tableName, columnList string) error {
-	if _, err := s.db.Exec(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", tableName, columnList)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s *SQLStore) createIndex(tableName, indexName, columnList string) error {
-	if _, err := s.db.Exec(fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s (%s)", indexName, tableName, columnList)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s *SQLStore) createUniqueIndex(tableName, indexName, columnList string) error {
-	if _, err := s.db.Exec(fmt.Sprintf("CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s (%s)", indexName, tableName, columnList)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s *SQLStore) addColumn(tableName, columnName, columnDefinition string) error {
-	if _, err := s.db.Exec(fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s", tableName, columnName, columnDefinition)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s *SQLStore) addPrimaryKey(tableName, columnList string) error {
-	rows, err := s.db.Query(fmt.Sprintf("SELECT constraint_name from information_schema.table_constraints where table_name = '%s' and constraint_type='PRIMARY KEY'", tableName))
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-
-	var constraintName string
-	if rows.Next() {
-		if scanErr := rows.Scan(&constraintName); scanErr != nil {
-			return scanErr
-		}
-	}
-
-	if constraintName == "" {
-		if _, err := s.db.Exec(fmt.Sprintf("ALTER TABLE %s ADD PRIMARY KEY(%s)", tableName, columnList)); err != nil {
-			return err
-		}
-	} else if _, err := s.db.Exec(fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s, ADD PRIMARY KEY(%s)", tableName, constraintName, columnList)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (s *SQLStore) Init(remoteID string) error {
 	if err := s.createTable(subscriptionsTableName, "subscriptionID VARCHAR(255) PRIMARY KEY, type VARCHAR(255), msTeamsTeamID VARCHAR(255), msTeamsChannelID VARCHAR(255), msTeamsUserID VARCHAR(255), secret VARCHAR(255), expiresOn BIGINT"); err != nil {
 		return err
@@ -175,13 +118,19 @@ func (s *SQLStore) Init(remoteID string) error {
 		}
 	}
 
-	// dedup entries with multiples ms teams id
-	if err := s.runMSTeamUserIDDedup(); err != nil {
+	exist, err := s.indexExist(usersTableName, "idx_msteamssync_users_msteamsuserid_unq")
+	if err != nil {
 		return err
 	}
+	if !exist {
+		// dedup entries with multiples ms teams id
+		if err := s.runMSTeamUserIDDedup(); err != nil {
+			return err
+		}
 
-	if err := s.createMSTeamsUserIdUniqueIndex(); err != nil {
-		return err
+		if err := s.createMSTeamsUserIdUniqueIndex(); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
#### Summary

- Add UNIQUE index on our users table to ensure msteamsuserid is unique.
- Created a migration to ensure we only have one msteamsuserid before apply the index
- Move migrations related methods to the migration file.

This PR does not include any check on the constraint on purpose: this will help us find where and why this happens in the first place.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56982
