### PR TITLE
[RE:MM-57209]  Set EmailVerified to true when autopromoting through hook

### DIFF
--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -25,6 +25,7 @@ import (
 func (p *Plugin) UserWillLogIn(_ *plugin.Context, user *model.User) string {
 	if p.IsRemoteUser(user) && p.getConfiguration().AutomaticallyPromoteSyntheticUsers {
 		*user.RemoteId = ""
+		user.EmailVerified = true
 		if _, appErr := p.API.UpdateUser(user); appErr != nil {
 			p.API.LogWarn("Unable to promote synthetic user", "user_id", user.Id, "error", appErr.Error())
 			return "Unable to promote synthetic user"

--- a/server/message_hooks_test.go
+++ b/server/message_hooks_test.go
@@ -2740,3 +2740,106 @@ func TestGetMentionsData(t *testing.T) {
 		})
 	}
 }
+
+func TestUserWillLogin(t *testing.T) {
+	for _, test := range []struct {
+		Name                               string
+		User                               *model.User
+		UserIsRemote                       bool // the remote id is set by the plugin during the test
+		AutomaticallyPromoteSyntheticUsers bool
+		SetupAPI                           func(*plugintest.API)
+		SetupStore                         func(*storemocks.Store)
+		SetupClient                        func(*clientmocks.Client)
+		Result                             string
+	}{
+		{
+			Name: "Autopromotion works",
+			User: &model.User{
+				Id:            testutils.GetID(),
+				EmailVerified: false,
+			},
+			UserIsRemote:                       true,
+			AutomaticallyPromoteSyntheticUsers: true,
+			SetupAPI: func(api *plugintest.API) {
+				api.On("UpdateUser", mock.MatchedBy(func(user *model.User) bool {
+					if user.EmailVerified == false {
+						return false
+					}
+
+					if *user.RemoteId != "" {
+						return false
+					}
+
+					return true
+				})).Once().Return(nil, nil)
+				api.On("LogInfo", "Promoted synthetic user", "user_id", testutils.GetID()).Once()
+			},
+			SetupClient: func(client *clientmocks.Client) {
+				client.On("GetChat", testutils.GetChatID()).Return(&clientmodels.Chat{}, nil)
+			},
+			SetupStore: func(store *storemocks.Store) {},
+			Result:     "",
+		},
+		{
+			Name: "UpdateUser failed during autopromotion",
+			User: &model.User{
+				Id:            testutils.GetID(),
+				EmailVerified: false,
+			},
+			UserIsRemote:                       true,
+			AutomaticallyPromoteSyntheticUsers: true,
+			SetupAPI: func(api *plugintest.API) {
+				api.On("UpdateUser", mock.MatchedBy(func(user *model.User) bool {
+					if user.EmailVerified == false {
+						return false
+					}
+
+					if *user.RemoteId != "" {
+						return false
+					}
+
+					return true
+				})).Once().Return(nil, model.NewAppError("UpdateUser", "err from test", nil, "", 500))
+				api.On("LogWarn", "Failed to promote synthetic user", "user_id", testutils.GetID(), "err", "err from test").Once()
+			},
+			SetupClient: func(client *clientmocks.Client) {},
+			SetupStore:  func(store *storemocks.Store) {},
+			Result:      "Unable to promote synthetic user",
+		},
+		{
+			Name: "No autopromotion",
+			User: &model.User{
+				Id:            testutils.GetID(),
+				EmailVerified: false,
+			},
+			UserIsRemote:                       true,
+			AutomaticallyPromoteSyntheticUsers: false,
+			SetupAPI:                           func(api *plugintest.API) {},
+			SetupClient:                        func(client *clientmocks.Client) {},
+			SetupStore:                         func(store *storemocks.Store) {},
+			Result:                             "",
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			assert := assert.New(t)
+			p := newTestPlugin(t)
+			cfg := p.configuration
+			cfg.AutomaticallyPromoteSyntheticUsers = test.AutomaticallyPromoteSyntheticUsers
+
+			test.SetupAPI(p.API.(*plugintest.API))
+			test.SetupStore(p.store.(*storemocks.Store))
+
+			client := p.msteamsAppClient.(*clientmocks.Client)
+			test.SetupClient(client)
+
+			user := test.User
+			if test.UserIsRemote {
+				user.RemoteId = &p.remoteID
+			}
+
+			res := p.UserWillLogIn(nil, user)
+
+			assert.Equal(test.Result, res)
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
Just found a case I didn't see before for setting EmailVerified to `true` when doing an autopromotion!

Previous PR: https://github.com/mattermost/mattermost-plugin-msteams/pull/548

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57209
