### PR TITLE
MM-57508: status slash command

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -599,12 +599,12 @@ func (p *Plugin) executePromoteUserCommand(args *model.CommandArgs, parameters [
 func (p *Plugin) executeStatusCommand(args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	if storedToken, err := p.store.GetTokenForMattermostUser(args.UserId); err != nil {
 		// TODO: We will need to distinguish real errors from "row not found" later.
-		return p.cmdSuccess(args, "Your account is not connected to Teams.")
+		return p.cmdSuccess(args, "Your account isn't connected to MS Teams.")
 	} else if storedToken != nil {
-		return p.cmdSuccess(args, "Your account is connected to Teams.")
+		return p.cmdSuccess(args, "Your account is connected to MS Teams.")
 	}
 
-	return p.cmdSuccess(args, "Your account is not connected to Teams.")
+	return p.cmdSuccess(args, "Your account isn't connected to MS Teams.")
 }
 
 func getAutocompletePath(path string) string {

--- a/server/command.go
+++ b/server/command.go
@@ -81,6 +81,9 @@ func getAutocompleteData(syncLinkedChannels bool) *model.AutocompleteData {
 	disconnect := model.NewAutocompleteData("disconnect", "", "Disconnect your Mattermost account from your MS Teams account")
 	cmd.AddCommand(disconnect)
 
+	status := model.NewAutocompleteData("status", "", "Show your connection status")
+	cmd.AddCommand(status)
+
 	connectBot := model.NewAutocompleteData("connect-bot", "", "Connect the bot account (only system admins can do this)")
 	connectBot.RoleID = model.SystemAdminRoleId
 	cmd.AddCommand(connectBot)
@@ -150,6 +153,10 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 
 	if action == "promote" {
 		return p.executePromoteUserCommand(args, parameters)
+	}
+
+	if action == "status" {
+		return p.executeStatusCommand(args)
 	}
 
 	if p.getConfiguration().SyncLinkedChannels {
@@ -587,6 +594,17 @@ func (p *Plugin) executePromoteUserCommand(args *model.CommandArgs, parameters [
 	}
 
 	return p.cmdSuccess(args, "Account "+username+" has been promoted and updated the username to "+newUsername)
+}
+
+func (p *Plugin) executeStatusCommand(args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	if storedToken, err := p.store.GetTokenForMattermostUser(args.UserId); err != nil {
+		// TODO: We will need to distinguish real errors from "row not found" later.
+		return p.cmdSuccess(args, "Your account is not connected to Teams.")
+	} else if storedToken != nil {
+		return p.cmdSuccess(args, "Your account is connected to Teams.")
+	}
+
+	return p.cmdSuccess(args, "Your account is not connected to Teams.")
 }
 
 func getAutocompletePath(path string) string {

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -1338,6 +1338,8 @@ func TestStatusCommand(t *testing.T) {
 	team := th.SetupTeam(t)
 	user1 := th.SetupUser(t, team)
 
+	th.SetupWebsocketClientForUser(t, user1.Id)
+
 	t.Run("not connected", func(t *testing.T) {
 		th.Reset(t)
 
@@ -1348,7 +1350,8 @@ func TestStatusCommand(t *testing.T) {
 
 		commandResponse, appErr := th.p.executeStatusCommand(args)
 		require.Nil(t, appErr)
-		assertCommandResponse(t, "Your account is not connected to Teams.", commandResponse)
+		assertNoCommandResponse(t, commandResponse)
+		assertEphemeralResponse(th, t, args, "Your account is not connected to Teams.")
 	})
 
 	t.Run("no token", func(t *testing.T) {
@@ -1364,7 +1367,8 @@ func TestStatusCommand(t *testing.T) {
 
 		commandResponse, appErr := th.p.executeStatusCommand(args)
 		require.Nil(t, appErr)
-		assertCommandResponse(t, "Your account is not connected to Teams.", commandResponse)
+		assertNoCommandResponse(t, commandResponse)
+		assertEphemeralResponse(th, t, args, "Your account is not connected to Teams.")
 	})
 
 	t.Run("connected", func(t *testing.T) {
@@ -1380,6 +1384,7 @@ func TestStatusCommand(t *testing.T) {
 
 		commandResponse, appErr := th.p.executeStatusCommand(args)
 		require.Nil(t, appErr)
-		assertCommandResponse(t, "Your account is connected to Teams.", commandResponse)
+		assertNoCommandResponse(t, commandResponse)
+		assertEphemeralResponse(th, t, args, "Your account is connected to Teams.")
 	})
 }

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -1351,7 +1351,7 @@ func TestStatusCommand(t *testing.T) {
 		commandResponse, appErr := th.p.executeStatusCommand(args)
 		require.Nil(t, appErr)
 		assertNoCommandResponse(t, commandResponse)
-		assertEphemeralResponse(th, t, args, "Your account is not connected to Teams.")
+		assertEphemeralResponse(th, t, args, "Your account isn't connected to MS Teams.")
 	})
 
 	t.Run("no token", func(t *testing.T) {
@@ -1368,7 +1368,7 @@ func TestStatusCommand(t *testing.T) {
 		commandResponse, appErr := th.p.executeStatusCommand(args)
 		require.Nil(t, appErr)
 		assertNoCommandResponse(t, commandResponse)
-		assertEphemeralResponse(th, t, args, "Your account is not connected to Teams.")
+		assertEphemeralResponse(th, t, args, "Your account isn't connected to MS Teams.")
 	})
 
 	t.Run("connected", func(t *testing.T) {
@@ -1385,6 +1385,6 @@ func TestStatusCommand(t *testing.T) {
 		commandResponse, appErr := th.p.executeStatusCommand(args)
 		require.Nil(t, appErr)
 		assertNoCommandResponse(t, commandResponse)
-		assertEphemeralResponse(th, t, args, "Your account is connected to Teams.")
+		assertEphemeralResponse(th, t, args, "Your account is connected to MS Teams.")
 	})
 }


### PR DESCRIPTION
#### Summary
Add a `/msteams status` slash command to show connection status:
![CleanShot 2024-03-29 at 14 18 45@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/3c273fdb-35d8-4f12-98a5-da5e48d04d90)

and similarly:
![CleanShot 2024-03-29 at 14 19 03@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/a5b31584-769c-4006-88be-264f70227600)

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-57508