### PR TITLE
MM-57506: use old CSS syntax

### DIFF
--- a/assets/info-page/index.html
+++ b/assets/info-page/index.html
@@ -56,329 +56,331 @@
       }
     </script>
     <style>
-      @font-face {
-          font-family: 'Metropolis';
-          font-style: normal;
-          font-weight: 600;
-          src: url('./static/fonts/Metropolis-SemiBold.woff') format('woff');
-      }
-
-      /* open-sans-300italic - vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic */
-      @font-face {
-          font-family: 'Open Sans';
-          font-style: italic;
-          font-weight: 300;
-          src:
-              local(''),
-              url('./static/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-300italic.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-              url('./static/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-300italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
-      }
-
-      /* open-sans-regular - vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic */
-      @font-face {
-          font-family: 'Open Sans';
-          font-style: normal;
-          font-weight: 400;
-          src:
-              local(''),
-              url('./static/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-              url('./static/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
-      }
-
-      /* open-sans-600 - vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic */
-      @font-face {
-          font-family: 'Open Sans';
-          font-style: normal;
-          font-weight: 600;
-          src:
-              local(''),
-              url('./static/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-600.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-              url('./static/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-600.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
-      }
-
-      @keyframes expand-card {
-        from {
-          max-height: 0;
-          padding: 0 16px;
+        @font-face {
+                font-family: 'Metropolis';
+                font-style: normal;
+                font-weight: 600;
+                src: url('./static/fonts/Metropolis-SemiBold.woff') format('woff');
         }
-        to {
-          max-height: 400px;
-          padding: 16px;
+
+              /* open-sans-300italic - vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic */
+        @font-face {
+                font-family: 'Open Sans';
+                  font-style: italic;
+                  font-weight: 300;
+                  src:
+                      local(''),
+                      url('./static/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-300italic.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+                      url('./static/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-300italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */;
         }
-      }
 
-      @keyframes collapse-card {
-        from {
-          max-height: 400px;
-          padding: 16px;
+              /* open-sans-regular - vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic */
+        @font-face {
+                font-family: 'Open Sans';
+                  font-style: normal;
+                  font-weight: 400;
+                  src:
+                      local(''),
+                      url('./static/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+                      url('./static/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */;
         }
-        to {
-          max-height: 0;
-          padding: 0 16px;
+
+              /* open-sans-600 - vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic */
+        @font-face {
+                font-family: 'Open Sans';
+                  font-style: normal;
+                  font-weight: 600;
+                  src:
+                      local(''),
+                      url('./static/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-600.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+                      url('./static/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-600.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */;
         }
-      }
 
-      body {
-        font-size: 14px;
-        line-height: 20px;
-        -webkit-font-smoothing: antialiased;
-        margin: 0px;
-      }
+        @keyframes expand-card {
+                from {
+                        max-height: 0;
+                        padding: 0 16px;
+                }
 
-      .msteams-sync-info-page {
-        max-width: 100%;
-        display: flex;
-        flex-direction: row-reverse;
-        padding: 0 20px;
-        min-height: 100vh;
-      }
+                to {
+                        max-height: 400px;
+                        padding: 16px;
+                }
+        }
 
-      .msteams-sync-close-icon {
-        position: absolute;
-        top: 24px;
-        right: 24px;
-        width: 20px;
-        height: 20px;
-        cursor: pointer;
-        border-radius: 4px;
-        padding: 10px;
+        @keyframes collapse-card {
+                from {
+                        max-height: 400px;
+                        padding: 16px;
+                }
 
-        &:hover {
-          background-color: rgba(63, 67, 80, 0.08);
+                to {
+                        max-height: 0;
+                        padding: 0 16px;
+                }
+        }
+
+        body {
+                font-size: 14px;
+                line-height: 20px;
+                -webkit-font-smoothing: antialiased;
+                margin: 0px;
+        }
+
+        .msteams-sync-info-page {
+                max-width: 100%;
+                display: flex;
+                flex-direction: row-reverse;
+                padding: 0 20px;
+                min-height: 100vh;
+        }
+
+        .msteams-sync-close-icon {
+                position: absolute;
+                top: 24px;
+                right: 24px;
+                width: 20px;
+                height: 20px;
+                cursor: pointer;
+                border-radius: 4px;
+                padding: 10px;
+        }
+
+        .msteams-sync-close-icon:hover {
+                background-color: rgba(63, 67, 80, 0.08);
+        }
+
+        .msteams-sync-body {
+                color: #3F4350;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                font-family: 'Open Sans';
+                width: 99%;
+                align-self: center;
+        }
+
+        .msteams-sync-body .heading-body {
+                margin-bottom: 32px;
+        }
+
+        .msteams-sync-body .connection-icon {
+                width: 390px;
+        }
+
+        .msteams-sync-body .heading {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                font-weight: 600;
+                font-size: 32px;
+                line-height: 40px;
+                letter-spacing: -0.32px;
+                text-align: center;
+                font-family: 'Metropolis';
+        }
+
+        .msteams-sync-body .connection-icon {
+                display: flex;
+                justify-content: center;
+        }
+
+        .msteams-sync-body .card-holder {
+                display: flex;
+                width: 1000px;
+                max-width: 95%;
+                justify-content: space-between;
+                box-sizing: border-box;
+        }
+
+        .msteams-sync-body .d-none {
+                display: none;
+        }
+
+        .msteams-sync-body .color-none {
+                outline: 3px solid transparent !important;
+                box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.08);
+        }
+
+        .msteams-sync-body .color-none:hover {
+                border: 1px solid rgba(63, 67, 80, 0.24);
+                box-shadow: 0px 4px 6px 0px rgba(0, 0, 0, 0.12);
+        }
+
+        .msteams-sync-body .card {
+                display: flex;
+                flex-direction: column;
+                border: 1px solid #3F435029;
+                outline: 3px solid #1C58D9;
+                border-radius: 8px;
+                box-sizing: border-box;
+                width: 49%;
+                cursor: pointer;
+        }
+
+        .msteams-sync-body .card__heading {
+                display: flex;
+                padding: 16px 24px;
+                border-bottom: 1px solid #3F435029;
+                align-items: center;
+                width: 100%;
+                box-sizing: border-box;
+        }
+
+        .msteams-sync-body .card__logo {
+                height: 42px;
+                width: 45px;
+        }
+
+        .msteams-sync-body .card__logo-details {
+                font-weight: 600;
+                font-size: 20px;
+                margin-left: 15px;
+                width: 70%;
+                font-family: 'Metropolis';
+        }
+
+        .msteams-sync-body .select-icon {
+                margin-left: auto;
+        }
+
+        .msteams-sync-body .card__body {
+                width: 100%;
+                height: 60%;
+                box-sizing: border-box;
+                padding: 16px 24px;
+        }
+
+        .msteams-sync-body .card__sub-heading {
+                font-weight: 600;
+        }
+
+        .msteams-sync-body .list {
+                list-style: none;
+                padding: 0;
+        }
+
+        .msteams-sync-body .list-item {
+                display: flex;
+                gap: 5px;
+                margin-bottom: 10px;
+        }
+
+        .msteams-sync-body .list-icon {
+                height: 20px;
+        }
+
+        .msteams-sync-body .list-link {
+                text-decoration: none;
+                display: contents;
+                color: #1C58D9;
+        }
+
+        .msteams-sync-body .selection-button {
+                text-align: center;
+                cursor: pointer;
+        }
+
+        .msteams-sync-body .selection-button__text {
+                background-color: #1C58D9;
+                color: white;
+        }
+
+        .msteams-sync-body .selection-button__text:hover {
+                background-color: #1A51C8;
+        }
+
+        .msteams-sync-body .skip-button__text {
+                background-color: rgba(28,88,217,0.08);
+                color: #1C58D9;
+        }
+
+        .msteams-sync-body .skip-button__text:hover {
+                background-color: rgba(28, 88, 217, 0.16);
+        }
+
+        .msteams-sync-body .button__container {
+                gap: 8px;
+                margin: 40px 0;
+                display: flex;
+        }
+
+        .msteams-sync-body .button__text {
+                display: flex;
+                gap: 10px;
+                padding: 15px 32px;
+                border-radius: 4px;
+                text-decoration: none;
+                font-size: 16px;
+                line-height: 24px;
+                font-weight: 600;
+                justify-content: center;
+        }
+
+        .msteams-sync-body .footer {
+                text-align: center;
+        }
+
+        .msteams-sync-body .footer-link {
+                text-decoration: none;
+        }
+
+        .msteams-sync-body .mobile-only {
+                display: none;
         }
 
         @media screen and (max-width: 680px) {
-          display: none;
-        }
-      }
 
-      .msteams-sync-body {
-        color: #3F4350;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        font-family: 'Open Sans';
-        width: 99%;
-        align-self: center;
+                .msteams-sync-body .msteams-sync-close-icon {
+                        display: none;
+                }
 
-        .heading-body {
-          margin-bottom: 32px;
-        }
+                .msteams-sync-body .mobile-only {
+                        display: unset;
+                }
 
-        .connection-icon {
-          width: 390px;
-        }
+                .msteams-sync-body .web-only {
+                        display: none;
+                }
 
-        .heading {
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          font-weight: 600;
-          font-size: 32px;
-          line-height: 40px;
-          letter-spacing: -0.32px;
-          text-align: center;
-          font-family: 'Metropolis';
-        }
+                .msteams-sync-body .button__container {
+                        flex-direction: column-reverse;
+                        width: 100%;
+                }
 
-        .connection-icon {
-          display: flex;
-          justify-content: center;
-        }
+                .msteams-sync-body .card-holder {
+                        display: flex;
+                        flex-direction: column;
+                        gap: 24px;
+                }
 
-        .card-holder {
-          display: flex;
-          width: 1000px;
-          max-width: 95%;
-          justify-content: space-between;
-          box-sizing: border-box;
-        }
+                .msteams-sync-body .card {
+                        width: 100%;
+                }
 
-        .d-none {
-          display: none;
+                .msteams-sync-body .card__body {
+                        height: auto;
+                        max-height: 0;
+                        padding: 0 16px;
+                        overflow: hidden;
+                }
+
+                .msteams-sync-body .card__body.expanded {
+                        animation-name: expand-card;
+                        animation-duration: 300ms;
+                        animation-fill-mode: forwards;
+                }
+
+                .msteams-sync-body .card__body.collapsed {
+                        animation-name: collapse-card;
+                        animation-duration: 300ms;
+                        animation-fill-mode: forwards;
+                }
         }
 
-        .color-none {
-          outline: 3px solid transparent !important;
-          box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.08);
-
-          &:hover {
-            border: 1px solid var(rgba(0, 0, 0, 0.24, rgba(63, 67, 80, 0.24)));
-            box-shadow: 0px 4px 6px 0px rgba(0, 0, 0, 0.12);
-          }
+        .msteams-sync-hidden {
+                display: none;
         }
-
-        .card {
-          display: flex;
-          flex-direction: column;
-          border: 1px solid #3F435029;
-          outline: 3px solid #1C58D9;
-          border-radius: 8px;
-          box-sizing: border-box;
-          width: 49%;
-          cursor: pointer;
-        }
-
-        .card__heading {
-          display: flex;
-          padding: 16px 24px;
-          border-bottom: 1px solid #3F435029;
-          align-items: center;
-          width: 100%;
-          box-sizing: border-box;
-        }
-
-        .card__logo {
-          height: 42px;
-          width: 45px
-        }
-
-        .card__logo-details {
-          font-weight: 600;
-          font-size: 20px;
-          margin-left: 15px;
-          width: 70%;
-          font-family: 'Metropolis';
-        }
-
-        .select-icon {
-          margin-left: auto;
-        }
-
-        .card__body {
-          width: 100%;
-          height: 60%;
-          box-sizing: border-box;
-          padding: 16px 24px;
-        }
-
-        .card__sub-heading {
-          font-weight: 600;
-        }
-
-        .list {
-          list-style: none;
-          padding: 0;
-        }
-
-        .list-item {
-          display: flex;
-          gap: 5px;
-          margin-bottom: 10px;
-        }
-
-        .list-icon {
-          height: 20px;
-        }
-
-        .list-link {
-          text-decoration: none;
-          display: contents;
-          color: #1C58D9;
-        }
-
-        .selection-button {
-          text-align: center;
-          cursor: pointer;
-        }
-
-        .selection-button__text {
-          background-color: #1C58D9;
-          color: white;
-
-          &:hover {
-            background-color: #1A51C8;
-          }
-        }
-
-        .skip-button__text {
-          background-color: rgba(28,88,217,0.08);
-          color: #1C58D9;
-
-          &:hover {
-            background-color: rgba(28, 88, 217, 0.16);
-          }
-        }
-
-        .button__container {
-          gap: 8px;
-          margin: 40px 0;
-          display: flex;
-        }
-
-        .button__text {
-          display: flex;
-          gap: 10px;
-          padding: 15px 32px;
-          border-radius: 4px;
-          text-decoration: none;
-          font-size: 16px;
-          line-height: 24px;
-          font-weight: 600;
-          justify-content: center;
-        }
-
-        .footer {
-          text-align: center;
-        }
-
-        .footer-link {
-          text-decoration: none;
-        }
-
-        .mobile-only {
-          display: none;
-        }
-
-        @media screen and (max-width: 680px) {
-          .mobile-only {
-            display: unset;
-          }
-
-          .web-only {
-            display: none;
-          }
-
-          .button__container {
-            flex-direction: column-reverse;
-            width: 100%;
-          }
-
-          .card-holder {
-            display: flex;
-            flex-direction: column;
-            gap: 24px;
-          }
-
-          .card {
-            width: 100%;
-          }
-
-          .card__body {
-            height: auto;
-            max-height: 0;
-            padding: 0 16px;
-            overflow: hidden;
-
-            &.expanded {
-              animation-name: expand-card;
-              animation-duration: 300ms;
-              animation-fill-mode: forwards;
-            }
-
-            &.collapsed {
-              animation-name: collapse-card;
-              animation-duration: 300ms;
-              animation-fill-mode: forwards;
-            }
-          }
-        }
-      }
-
-      .msteams-sync-hidden {
-        display: none;
-      }
-
     </style>
     <title>Microsoft Teams Connection Information</title>
   </head>


### PR DESCRIPTION
#### Summary
Firefox ESR doesn't support nested CSS selectors: switch back to the old-style version instead, and fix a handful of other syntax errors. Push it through a CSS beautifier as well.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-57506