### PR TITLE
MM-57120: show connected users stat

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -72,6 +72,7 @@ func NewAPI(p *Plugin, store store.Store) *API {
 	router.HandleFunc("/connected-users/download", api.getConnectedUsersFile).Methods(http.MethodGet)
 	router.HandleFunc("/notify-connect", api.notifyConnect).Methods("GET")
 	router.HandleFunc(APIChoosePrimaryPlatform, api.choosePrimaryPlatform).Methods(http.MethodGet)
+	router.HandleFunc("/stats/site", api.siteStats).Methods("GET")
 
 	// iFrame support
 	router.HandleFunc("/iframe/mattermostTab", api.iFrame).Methods("GET")
@@ -708,4 +709,36 @@ func GetPageAndPerPage(r *http.Request) (page, perPage int) {
 	}
 
 	return page, perPage
+}
+
+func (a *API) siteStats(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("Mattermost-User-ID")
+
+	if !a.p.API.HasPermissionTo(userID, model.PermissionManageSystem) {
+		a.p.API.LogWarn("Insufficient permissions", "user_id", userID)
+		http.Error(w, "not able to authorize the user", http.StatusForbidden)
+		return
+	}
+
+	stats, err := a.p.store.GetStats()
+	if err != nil {
+		a.p.API.LogWarn("Failed to get site stats", "error", err.Error())
+		http.Error(w, "unable to get site stats", http.StatusInternalServerError)
+		return
+	}
+
+	siteStats := struct {
+		TotalConnectedUsers int64 `json:"total_connected_users"`
+	}{
+		TotalConnectedUsers: stats.ConnectedUsers,
+	}
+
+	data, err := json.Marshal(siteStats)
+	if err != nil {
+		a.p.API.LogWarn("Failed to marshal site stats", "error", err.Error())
+		http.Error(w, "unable to get site stats", http.StatusInternalServerError)
+		return
+	}
+
+	_, _ = w.Write(data)
 }

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -6,6 +6,10 @@ import {ClientError} from 'mattermost-redux/client/client4';
 
 import {id as pluginId} from './manifest';
 
+export interface SiteStats {
+    total_connected_users: number;
+}
+
 class ClientClass {
     url = '';
 
@@ -15,6 +19,14 @@ class ClientClass {
 
     notifyConnect = async () => {
         await this.doGet(`${this.url}/notify-connect`);
+    };
+
+    fetchSiteStats = async (): Promise<SiteStats | null> => {
+        const data = await this.doGet(`${this.url}/stats/site`);
+        if (!data) {
+            return null;
+        }
+        return data as SiteStats;
     };
 
     doGet = async (url: string, headers: {[key: string]: any} = {}) => {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -79,6 +79,21 @@ export default class Plugin {
                 registry.registerUserSettings?.(getSettings(serverRoute, !settingsEnabled));
             }
         });
+
+        // Site statistics handler
+        if (registry.registerSiteStatisticsHandler) {
+            registry.registerSiteStatisticsHandler(async () => {
+                const siteStats = await Client.fetchSiteStats();
+                return {
+                    msteams_connected_users: {
+                        name: 'MS Teams: Connected Users',
+                        id: 'msteams_connected_users',
+                        icon: 'fa-users', // font-awesome-4.7.0 handler
+                        value: siteStats?.total_connected_users,
+                    },
+                };
+            });
+        }
     }
 
     userActivityWatch(): void {

--- a/webapp/src/types/mattermost-webapp/index.d.ts
+++ b/webapp/src/types/mattermost-webapp/index.d.ts
@@ -80,6 +80,7 @@ export interface PluginRegistry {
     registerRootComponent(component: React.ElementType)
     registerAdminConsoleCustomSetting(key: string, component: React.ElementType)
     registerUserSettings?(setting: PluginConfiguration)
+    registerSiteStatisticsHandler(handler: any)
 
     // Add more if needed from https://developers.mattermost.com/extend/plugins/webapp/reference
 }


### PR DESCRIPTION
#### Summary
Show the number of connected users on the system console for administrators.

![CleanShot 2024-03-30 at 15 38 41@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/007fa780-01d1-4ab2-9d2a-8771c0d8f92a)

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-57350