### PR TITLE
[MM-57568] Synthetic user created from DM/GM have wrong RemoteID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/microsoft/kiota-http-go v1.3.1
 	github.com/microsoftgraph/msgraph-sdk-go v1.36.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.1.0
-	github.com/pborman/uuid v1.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.0
 	github.com/sirupsen/logrus v1.9.3
@@ -99,6 +98,7 @@ require (
 	github.com/oov/psd v0.0.0-20220121172623-5db5eafcecbb // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc5 // indirect
+	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/philhofer/fwd v1.1.2 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect

--- a/server/handlers/getters.go
+++ b/server/handlers/getters.go
@@ -1,14 +1,12 @@
 package handlers
 
 import (
-	"encoding/base32"
 	"fmt"
 
 	"github.com/gosimple/slug"
 	"github.com/mattermost/mattermost-plugin-msteams/server/msteams"
 	"github.com/mattermost/mattermost-plugin-msteams/server/msteams/clientmodels"
 	"github.com/mattermost/mattermost/server/public/model"
-	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -109,9 +107,7 @@ func (ah *ActivityHandler) getOrCreateSyntheticUser(user *clientmodels.User, cre
 		}
 
 		userDisplayName := user.DisplayName
-		memberUUID := uuid.Parse(user.ID)
-		encoding := base32.NewEncoding("ybndrfg8ejkmcpqxot1uwisza345h769").WithPadding(base32.NoPadding)
-		shortUserID := encoding.EncodeToString(memberUUID)
+		remoteID := ah.plugin.GetRemoteID()
 		username := "msteams_" + slug.Make(userDisplayName)
 
 		newMMUser := &model.User{
@@ -119,7 +115,7 @@ func (ah *ActivityHandler) getOrCreateSyntheticUser(user *clientmodels.User, cre
 			FirstName: userDisplayName,
 			Email:     user.Mail,
 			Password:  ah.plugin.GenerateRandomPassword(),
-			RemoteId:  &shortUserID,
+			RemoteId:  &remoteID,
 		}
 		newMMUser.SetDefaultNotifications()
 		newMMUser.NotifyProps[model.EmailNotifyProp] = "false"

--- a/server/handlers/getters_test.go
+++ b/server/handlers/getters_test.go
@@ -40,6 +40,7 @@ type pluginMock struct {
 	teamsUserClient            msteams.Client
 	metrics                    metrics.Metrics
 	selectiveSync              bool
+	remoteID                   string
 }
 
 func (pm *pluginMock) GetAPI() plugin.API                              { return pm.api }
@@ -54,6 +55,7 @@ func (pm *pluginMock) GetBufferSizeForStreaming() int                  { return 
 func (pm *pluginMock) GetBotUserID() string                            { return pm.botUserID }
 func (pm *pluginMock) GetURL() string                                  { return pm.url }
 func (pm *pluginMock) IsRemoteUser(user *model.User) bool              { return user.RemoteId != nil }
+func (pm *pluginMock) GetRemoteID() string                             { return pm.remoteID }
 func (pm *pluginMock) GetMetrics() metrics.Metrics                     { return pm.metrics }
 func (pm *pluginMock) GetClientForApp() msteams.Client                 { return pm.appClient }
 func (pm *pluginMock) GetClientForUser(string) (msteams.Client, error) { return pm.userClient, nil }
@@ -81,6 +83,7 @@ func newTestHandler() *ActivityHandler {
 		syncGuestUsers:             false,
 		maxSizeForCompleteDownload: 20,
 		bufferSizeForStreaming:     20,
+		remoteID:                   "remote-id",
 	})
 }
 

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -53,6 +53,7 @@ type PluginIface interface {
 	ChatSpansPlatforms(channelID string) (bool, *model.AppError)
 	GetSelectiveSync() bool
 	IsRemoteUser(user *model.User) bool
+	GetRemoteID() string
 }
 
 type ActivityHandler struct {

--- a/server/handlers/mocks/PluginIface.go
+++ b/server/handlers/mocks/PluginIface.go
@@ -193,6 +193,20 @@ func (_m *PluginIface) GetMetrics() metrics.Metrics {
 	return r0
 }
 
+// GetRemoteID provides a mock function with given fields:
+func (_m *PluginIface) GetRemoteID() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // GetSelectiveSync provides a mock function with given fields:
 func (_m *PluginIface) GetSelectiveSync() bool {
 	ret := _m.Called()

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -860,6 +860,10 @@ func (p *Plugin) IsRemoteUser(user *model.User) bool {
 	return user.RemoteId != nil && *user.RemoteId == p.remoteID
 }
 
+func (p *Plugin) GetRemoteID() string {
+	return p.remoteID
+}
+
 func (p *Plugin) updateMetrics() {
 	stats, err := p.store.GetStats()
 	if err != nil {


### PR DESCRIPTION
#### Summary
When creating a synthetic user from a DM/GM, we set a remoteID based on the user UUID instead of using the plugin remoteID.

Example of how it's done for the syncUsers job: https://github.com/mattermost/mattermost-plugin-msteams/blob/main/server/plugin.go#L727

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57568
