### PR TITLE
MM-57494: welcome message after connecting

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -447,6 +447,8 @@ func (a *API) oauthRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	a.p.notifyUserConnected(mmUserID)
+
 	a.p.whitelistClusterMutex.Lock()
 	defer a.p.whitelistClusterMutex.Unlock()
 

--- a/server/automute_channel.go
+++ b/server/automute_channel.go
@@ -10,6 +10,11 @@ import (
 )
 
 func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, actor *model.User) {
+	p.API.LogDebug(
+		"User has joine channel",
+		"user_id", channelMember.UserId,
+		"channel_id", channelMember.ChannelId,
+	)
 	_, _ = p.updateAutomutingOnUserJoinedChannel(c, channelMember.UserId, channelMember.ChannelId)
 }
 

--- a/server/automute_preferences.go
+++ b/server/automute_preferences.go
@@ -23,6 +23,8 @@ func (p *Plugin) updateAutomutingOnPreferencesChanged(c *plugin.Context, prefere
 			continue
 		}
 
+		p.notifyUserTeamsPrimary(userID)
+
 		if _, err := p.enableAutomute(userID); err != nil {
 			p.API.LogWarn(
 				"Unable to mute channels for a user who set their primary platform to Teams",
@@ -33,6 +35,8 @@ func (p *Plugin) updateAutomutingOnPreferencesChanged(c *plugin.Context, prefere
 	}
 
 	for _, userID := range userIDsToDisable {
+		p.notifyUserMattermostPrimary(userID)
+
 		_, err := p.disableAutomute(userID)
 		if err != nil {
 			p.API.LogWarn(

--- a/server/automute_preferences_test.go
+++ b/server/automute_preferences_test.go
@@ -2,42 +2,52 @@ package main
 
 import (
 	"testing"
+	"time"
 
+	"github.com/mattermost/mattermost-plugin-msteams/server/store/storemodels"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
+	th := setupTestHelper(t)
+
+	team := th.SetupTeam(t)
+
 	setup := func(t *testing.T) (*Plugin, *model.User, *model.Channel, *model.Channel, *model.Channel) {
 		t.Helper()
+		th.Reset(t)
 
-		p := newAutomuteTestPlugin(t)
+		user := th.SetupUser(t, team)
+		err := th.p.store.SetUserInfo(user.Id, "team_user_id", &oauth2.Token{AccessToken: "token", Expiry: time.Now().Add(10 * time.Minute)})
+		require.NoError(t, err)
 
-		user := &model.User{Id: model.NewId()}
-		mockUserConnected(p, user.Id)
+		linkedChannel := th.SetupPublicChannel(t, team, WithMembers(user))
 
-		linkedChannel, appErr := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
+		channelLink := storemodels.ChannelLink{
+			MattermostTeamID:    team.Id,
+			MattermostChannelID: linkedChannel.Id,
+			MSTeamsTeam:         model.NewId(),
+			MSTeamsChannel:      model.NewId(),
+			Creator:             user.Id,
+		}
+		err = th.p.store.StoreChannelLink(&channelLink)
+		require.NoError(t, err)
+
+		unlinkedChannel := th.SetupPublicChannel(t, team, WithMembers(user))
+
+		otherUser := th.SetupUser(t, team)
+		dmChannel, appErr := th.p.API.GetDirectChannel(user.Id, otherUser.Id)
 		require.Nil(t, appErr)
-		_, appErr = p.API.AddUserToChannel(linkedChannel.Id, user.Id, "")
-		require.Nil(t, appErr)
-		mockLinkedChannel(p, linkedChannel)
 
-		unlinkedChannel, appErr := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
-		require.Nil(t, appErr)
-		_, appErr = p.API.AddUserToChannel(unlinkedChannel.Id, user.Id, "")
-		require.Nil(t, appErr)
-		mockUnlinkedChannel(p, unlinkedChannel)
+		assertChannelNotAutomuted(t, th.p, linkedChannel.Id, user.Id)
+		assertChannelNotAutomuted(t, th.p, unlinkedChannel.Id, user.Id)
+		assertChannelNotAutomuted(t, th.p, dmChannel.Id, user.Id)
 
-		dmChannel, appErr := p.API.GetDirectChannel(user.Id, model.NewId())
-		require.Nil(t, appErr)
-
-		assertChannelNotAutomuted(t, p, linkedChannel.Id, user.Id)
-		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
-		assertChannelNotAutomuted(t, p, dmChannel.Id, user.Id)
-
-		return p, user, linkedChannel, unlinkedChannel, dmChannel
+		return th.p, user, linkedChannel, unlinkedChannel, dmChannel
 	}
 
 	t.Run("should mute linked channels when their primary platform changes from MM to MS Teams", func(t *testing.T) {
@@ -124,15 +134,15 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 	t.Run("should do nothing when an unconnected user turns on automuting", func(t *testing.T) {
 		p, _, linkedChannel, unlinkedChannel, _ := setup(t)
 
-		unconnectedUser := &model.User{Id: model.NewId()}
-		mockUserNotConnected(p, unconnectedUser.Id)
+		unconnectedUser := th.SetupUser(t, team)
+		otherUser := th.SetupUser(t, team)
 
 		_, appErr := p.API.AddUserToChannel(linkedChannel.Id, unconnectedUser.Id, "")
 		require.Nil(t, appErr)
 		_, appErr = p.API.AddUserToChannel(unlinkedChannel.Id, unconnectedUser.Id, "")
 		require.Nil(t, appErr)
 
-		dmChannel, appErr := p.API.GetDirectChannel(unconnectedUser.Id, model.NewId())
+		dmChannel, appErr := p.API.GetDirectChannel(unconnectedUser.Id, otherUser.Id)
 		require.Nil(t, appErr)
 
 		p.PreferencesHaveChanged(&plugin.Context{}, []model.Preference{
@@ -154,16 +164,15 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 	t.Run("should not affect other users when a connected user turns on automuting", func(t *testing.T) {
 		p, user, linkedChannel, unlinkedChannel, _ := setup(t)
 
-		connectedUser := &model.User{Id: model.NewId()}
-		mockUserConnected(p, connectedUser.Id)
+		connectedUser := th.SetupUser(t, team)
+		th.ConnectUser(t, connectedUser.Id)
 
 		_, appErr := p.API.AddUserToChannel(linkedChannel.Id, connectedUser.Id, "")
 		require.Nil(t, appErr)
 		_, appErr = p.API.AddUserToChannel(unlinkedChannel.Id, connectedUser.Id, "")
 		require.Nil(t, appErr)
 
-		unconnectedUser := &model.User{Id: model.NewId()}
-		mockUserNotConnected(p, unconnectedUser.Id)
+		unconnectedUser := th.SetupUser(t, team)
 
 		_, appErr = p.API.AddUserToChannel(linkedChannel.Id, unconnectedUser.Id, "")
 		require.Nil(t, appErr)
@@ -201,12 +210,9 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		numChannels := 1000
 		channels := make([]*model.Channel, numChannels)
 		for i := 0; i < numChannels; i++ {
-			channel, appErr := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
-			require.Nil(t, appErr)
-			_, appErr = p.API.AddUserToChannel(channel.Id, user.Id, "")
-			require.Nil(t, appErr)
+			channel := th.SetupPublicChannel(t, team, WithMembers(user))
 
-			mockLinkedChannel(p, channel)
+			th.LinkChannel(t, team, channel, user)
 
 			channels[i] = channel
 		}

--- a/server/automute_test.go
+++ b/server/automute_test.go
@@ -1,344 +1,144 @@
 package main
 
 import (
-	"database/sql"
-	"strings"
 	"testing"
+	"time"
 
-	storemocks "github.com/mattermost/mattermost-plugin-msteams/server/store/mocks"
-	"github.com/mattermost/mattermost-plugin-msteams/server/store/storemodels"
 	"github.com/mattermost/mattermost/server/public/model"
-	"github.com/mattermost/mattermost/server/public/plugin"
-	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type AutomuteAPIMock struct {
-	*plugintest.API
-
-	plugin *Plugin
-
-	channels       map[string]*model.Channel
-	preferences    map[string]model.Preference
-	channelMembers map[string]*model.ChannelMember
-
-	t *testing.T
-}
-
-func (a *AutomuteAPIMock) key(parts ...string) string {
-	return strings.Join(parts, "-")
-}
-
-func (a *AutomuteAPIMock) GetPreferenceForUser(userID, category, name string) (model.Preference, *model.AppError) {
-	a.t.Helper()
-
-	preference, ok := a.preferences[a.key(userID, category, name)]
-	if !ok {
-		return model.Preference{}, &model.AppError{Message: "AutomuteAPIMock: Preference not found"}
-	}
-	return preference, nil
-}
-
-func (a *AutomuteAPIMock) UpdatePreferencesForUser(userID string, preferences []model.Preference) *model.AppError {
-	a.t.Helper()
-
-	for _, preference := range preferences {
-		a.preferences[a.key(userID, preference.Category, preference.Name)] = preference
-	}
-
-	a.plugin.PreferencesHaveChanged(&plugin.Context{}, preferences)
-
-	return nil
-}
-
-func (a *AutomuteAPIMock) CreateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
-	a.t.Helper()
-
-	a.channels[channel.Id] = channel
-
-	a.plugin.ChannelHasBeenCreated(&plugin.Context{}, channel)
-
-	return channel, nil
-}
-
-func (a *AutomuteAPIMock) GetDirectChannel(userID1, userID2 string) (*model.Channel, *model.AppError) {
-	a.t.Helper()
-
-	channel := &model.Channel{
-		Id:   model.NewId(),
-		Type: model.ChannelTypeDirect,
-	}
-	a.channels[channel.Id] = channel
-
-	_, appErr := a.AddUserToChannel(channel.Id, userID1, "")
-	require.Nil(a.t, appErr)
-	_, appErr = a.AddUserToChannel(channel.Id, userID2, "")
-	require.Nil(a.t, appErr)
-
-	a.plugin.ChannelHasBeenCreated(&plugin.Context{}, channel)
-
-	return channel, nil
-}
-
-func (a *AutomuteAPIMock) GetChannel(channelID string) (*model.Channel, *model.AppError) {
-	a.t.Helper()
-
-	channel, ok := a.channels[channelID]
-	if !ok {
-		return nil, &model.AppError{Message: "AutomuteAPIMock: Channel not found"}
-	}
-
-	return channel, nil
-}
-
-func (a *AutomuteAPIMock) AddUserToChannel(channelID, userID, asUserID string) (*model.ChannelMember, *model.AppError) {
-	a.t.Helper()
-
-	member := a.addMockChannelMember(channelID, userID)
-
-	a.plugin.UserHasJoinedChannel(&plugin.Context{}, member, &model.User{Id: asUserID})
-
-	return member, nil
-}
-
-func (a *AutomuteAPIMock) addMockChannelMember(channelID, userID string) *model.ChannelMember {
-	member := &model.ChannelMember{
-		UserId:      userID,
-		ChannelId:   channelID,
-		NotifyProps: model.GetDefaultChannelNotifyProps(),
-	}
-
-	a.channelMembers[a.key(channelID, userID)] = member
-
-	return member
-}
-
-func (a *AutomuteAPIMock) GetChannelsForTeamForUser(teamID, userID string, includeDeleted bool) ([]*model.Channel, *model.AppError) {
-	a.t.Helper()
-
-	if teamID != "" || !includeDeleted {
-		panic("Not implemented")
-	}
-
-	var channels []*model.Channel
-	for _, channelMember := range a.channelMembers {
-		if channelMember.UserId != userID {
-			continue
-		}
-
-		channels = append(channels, a.channels[channelMember.ChannelId])
-	}
-	return channels, nil
-}
-
-func (a *AutomuteAPIMock) GetChannelMember(channelID, userID string) (*model.ChannelMember, *model.AppError) {
-	a.t.Helper()
-
-	member, ok := a.channelMembers[a.key(channelID, userID)]
-	if !ok {
-		return nil, &model.AppError{Message: "AutomuteAPIMock: Channel member not found"}
-	}
-	return member, nil
-}
-
-func (a *AutomuteAPIMock) GetChannelMembers(channelID string, page, perPage int) (model.ChannelMembers, *model.AppError) {
-	a.t.Helper()
-
-	var members []model.ChannelMember
-	for _, member := range a.channelMembers {
-		if member.ChannelId == channelID {
-			members = append(members, *member)
-		}
-	}
-
-	if page*perPage > len(members) {
-		members = nil
-	} else {
-		members = members[page*perPage:]
-	}
-
-	if len(members) > perPage {
-		members = members[:perPage]
-	}
-
-	return members, nil
-}
-
-func (a *AutomuteAPIMock) PatchChannelMembersNotifications(identifiers []*model.ChannelMemberIdentifier, notifyProps map[string]string) *model.AppError {
-	a.t.Helper()
-
-	for _, identifier := range identifiers {
-		for propKey, propValue := range notifyProps {
-			a.channelMembers[a.key(identifier.ChannelId, identifier.UserId)].NotifyProps[propKey] = propValue
-		}
-	}
-
-	return nil
-}
-
-func (a *AutomuteAPIMock) LogDebug(msg string, keyValuePairs ...any) {
-	a.t.Log(msg, keyValuePairs)
-}
-
-func (a *AutomuteAPIMock) LogInfo(msg string, keyValuePairs ...any) {
-	a.t.Log(msg, keyValuePairs)
-}
-
-func (a *AutomuteAPIMock) LogError(msg string, keyValuePairs ...any) {
-	a.t.Error(msg, keyValuePairs)
-}
-
-func (a *AutomuteAPIMock) LogWarn(msg string, keyValuePairs ...any) {
-	a.t.Log(msg, keyValuePairs)
-}
-
-func newAutomuteTestPlugin(t *testing.T) *Plugin {
-	mockAPI := &AutomuteAPIMock{
-		API:            &plugintest.API{},
-		channels:       make(map[string]*model.Channel),
-		channelMembers: make(map[string]*model.ChannelMember),
-		preferences:    make(map[string]model.Preference),
-		t:              t,
-	}
-	t.Cleanup(func() { mockAPI.AssertExpectations(t) })
-
-	p := newTestPlugin(t)
-	p.SetAPI(mockAPI)
-
-	mockAPI.plugin = p
-
-	return p
-}
-
 func TestSetAutomuteEnabledForUser(t *testing.T) {
-	p := newAutomuteTestPlugin(t)
+	th := setupTestHelper(t)
+	team := th.SetupTeam(t)
 
-	user := &model.User{Id: model.NewId()}
+	user := th.SetupUser(t, team)
 
-	channel, appErr := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
+	channel := th.SetupPublicChannel(t, team, WithMembers(user))
+
+	otherUser := th.SetupUser(t, team)
+	directChannel, appErr := th.p.API.GetDirectChannel(user.Id, otherUser.Id)
 	require.Nil(t, appErr)
-	_, appErr = p.API.AddUserToChannel(channel.Id, user.Id, "")
-	require.Nil(t, appErr)
 
-	directChannel, appErr := p.API.GetDirectChannel(user.Id, model.NewId())
-	require.Nil(t, appErr)
-
-	mockLinkedChannel(p, channel)
+	th.LinkChannel(t, team, channel, user)
 
 	t.Run("initial conditions", func(t *testing.T) {
-		assertChannelNotAutomuted(t, p, channel.Id, user.Id)
-		assertChannelNotAutomuted(t, p, directChannel.Id, user.Id)
+		assertChannelNotAutomuted(t, th.p, channel.Id, user.Id)
+		assertChannelNotAutomuted(t, th.p, directChannel.Id, user.Id)
 	})
 
 	t.Run("should do nothing when false is passed and automuting has never been enabled", func(t *testing.T) {
-		result, err := p.setAutomuteEnabledForUser(user.Id, false)
+		result, err := th.p.setAutomuteEnabledForUser(user.Id, false)
 
 		assert.Equal(t, false, result)
 		assert.NoError(t, err)
 
-		assertChannelNotAutomuted(t, p, channel.Id, user.Id)
-		assertChannelNotAutomuted(t, p, directChannel.Id, user.Id)
+		assertChannelNotAutomuted(t, th.p, channel.Id, user.Id)
+		assertChannelNotAutomuted(t, th.p, directChannel.Id, user.Id)
 	})
 
 	t.Run("should automute all channels when true is passed and automuting has never been enabled", func(t *testing.T) {
-		result, err := p.setAutomuteEnabledForUser(user.Id, true)
+		result, err := th.p.setAutomuteEnabledForUser(user.Id, true)
 
 		assert.Equal(t, true, result)
 		assert.NoError(t, err)
 
-		assertChannelAutomuted(t, p, channel.Id, user.Id)
-		assertChannelAutomuted(t, p, directChannel.Id, user.Id)
+		assertChannelAutomuted(t, th.p, channel.Id, user.Id)
+		assertChannelAutomuted(t, th.p, directChannel.Id, user.Id)
 	})
 
 	t.Run("should do nothing when true is passed and automuting was last enabled", func(t *testing.T) {
-		result, err := p.setAutomuteEnabledForUser(user.Id, true)
+		result, err := th.p.setAutomuteEnabledForUser(user.Id, true)
 
 		assert.Equal(t, false, result)
 		assert.NoError(t, err)
 
-		assertChannelAutomuted(t, p, channel.Id, user.Id)
-		assertChannelAutomuted(t, p, directChannel.Id, user.Id)
+		assertChannelAutomuted(t, th.p, channel.Id, user.Id)
+		assertChannelAutomuted(t, th.p, directChannel.Id, user.Id)
 	})
 
 	t.Run("should un-automute all channels when false is passed and automuting was last enabled", func(t *testing.T) {
-		result, err := p.setAutomuteEnabledForUser(user.Id, false)
+		result, err := th.p.setAutomuteEnabledForUser(user.Id, false)
 
 		assert.Equal(t, true, result)
 		assert.NoError(t, err)
 
-		assertChannelNotAutomuted(t, p, channel.Id, user.Id)
-		assertChannelNotAutomuted(t, p, directChannel.Id, user.Id)
+		assertChannelNotAutomuted(t, th.p, channel.Id, user.Id)
+		assertChannelNotAutomuted(t, th.p, directChannel.Id, user.Id)
 	})
 
 	t.Run("should do nothing when false is passed and automuting was last disabled", func(t *testing.T) {
-		result, err := p.setAutomuteEnabledForUser(user.Id, false)
+		result, err := th.p.setAutomuteEnabledForUser(user.Id, false)
 
 		assert.Equal(t, false, result)
 		assert.NoError(t, err)
 
-		assertChannelNotAutomuted(t, p, channel.Id, user.Id)
-		assertChannelNotAutomuted(t, p, directChannel.Id, user.Id)
+		assertChannelNotAutomuted(t, th.p, channel.Id, user.Id)
+		assertChannelNotAutomuted(t, th.p, directChannel.Id, user.Id)
 	})
 
 	t.Run("should automute all channels when true is passed and automuting was last disabled", func(t *testing.T) {
-		result, err := p.setAutomuteEnabledForUser(user.Id, true)
+		result, err := th.p.setAutomuteEnabledForUser(user.Id, true)
 
 		assert.Equal(t, true, result)
 		assert.NoError(t, err)
 
-		assertChannelAutomuted(t, p, channel.Id, user.Id)
-		assertChannelAutomuted(t, p, directChannel.Id, user.Id)
+		assertChannelAutomuted(t, th.p, channel.Id, user.Id)
+		assertChannelAutomuted(t, th.p, directChannel.Id, user.Id)
 	})
 }
 
 func TestChannelsAutomutedPreference(t *testing.T) {
-	plugin := newAutomuteTestPlugin(t)
+	th := setupTestHelper(t)
 
-	user := &model.User{Id: model.NewId()}
+	team := th.SetupTeam(t)
+	user := th.SetupUser(t, team)
 
-	assert.False(t, plugin.getAutomuteIsEnabledForUser(user.Id))
+	assert.False(t, th.p.getAutomuteIsEnabledForUser(user.Id))
 
-	err := plugin.setAutomuteIsEnabledForUser(user.Id, true)
+	err := th.p.setAutomuteIsEnabledForUser(user.Id, true)
 	require.Nil(t, err)
 
-	assert.True(t, plugin.getAutomuteIsEnabledForUser(user.Id))
+	assert.True(t, th.p.getAutomuteIsEnabledForUser(user.Id))
 
-	err = plugin.setAutomuteIsEnabledForUser(user.Id, false)
+	err = th.p.setAutomuteIsEnabledForUser(user.Id, false)
 	require.Nil(t, err)
 
-	assert.False(t, plugin.getAutomuteIsEnabledForUser(user.Id))
+	assert.False(t, th.p.getAutomuteIsEnabledForUser(user.Id))
 }
 
 func TestCanAutomuteChannel(t *testing.T) {
+	th := setupTestHelper(t)
+	team := th.SetupTeam(t)
+	user := th.SetupUser(t, team)
+
 	t.Run("should return true for a linked channel", func(t *testing.T) {
-		p := newAutomuteTestPlugin(t)
+		channel := th.SetupPublicChannel(t, team)
+		th.LinkChannel(t, team, channel, user)
 
-		channel, appErr := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
-		require.Nil(t, appErr)
-		mockLinkedChannel(p, channel)
-
-		result, err := p.canAutomuteChannel(channel)
+		result, err := th.p.canAutomuteChannel(channel)
 		assert.NoError(t, err)
 		assert.Equal(t, true, result)
 
-		channel, appErr = p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypePrivate})
-		require.Nil(t, appErr)
-		mockLinkedChannel(p, channel)
+		channel = th.SetupPrivateChannel(t, team)
+		th.LinkChannel(t, team, channel, user)
 
-		result, err = p.canAutomuteChannel(channel)
+		result, err = th.p.canAutomuteChannel(channel)
 		assert.NoError(t, err)
 		assert.Equal(t, true, result)
 	})
 
 	t.Run("should return true for a DM/GM channel", func(t *testing.T) {
-		p := newAutomuteTestPlugin(t)
+		th.Reset(t)
 
-		channel, appErr := p.API.GetDirectChannel(model.NewId(), model.NewId())
+		user1 := th.SetupUser(t, team)
+		user2 := th.SetupUser(t, team)
+
+		channel, appErr := th.p.API.GetDirectChannel(user1.Id, user2.Id)
 		require.Nil(t, appErr)
-		mockUnlinkedChannel(p, channel)
 
-		result, err := p.canAutomuteChannel(channel)
+		result, err := th.p.canAutomuteChannel(channel)
 		assert.NoError(t, err)
 		assert.Equal(t, true, result)
 
@@ -346,21 +146,18 @@ func TestCanAutomuteChannel(t *testing.T) {
 			Id:   model.NewId(),
 			Type: model.ChannelTypeGroup,
 		}
-		mockUnlinkedChannel(p, channel)
 
-		result, err = p.canAutomuteChannel(channel)
+		result, err = th.p.canAutomuteChannel(channel)
 		assert.NoError(t, err)
 		assert.Equal(t, true, result)
 	})
 
 	t.Run("should return false for an unlinked channel", func(t *testing.T) {
-		p := newAutomuteTestPlugin(t)
+		th.Reset(t)
 
-		channel, appErr := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
-		require.Nil(t, appErr)
-		mockUnlinkedChannel(p, channel)
+		channel := th.SetupPublicChannel(t, team)
 
-		result, err := p.canAutomuteChannel(channel)
+		result, err := th.p.canAutomuteChannel(channel)
 		assert.NoError(t, err)
 		assert.Equal(t, false, result)
 	})
@@ -387,50 +184,37 @@ func assertUserHasAutomuteDisabled(t *testing.T, p *Plugin, userID string) {
 func assertChannelAutomuted(t *testing.T, p *Plugin, channelID, userID string) {
 	t.Helper()
 
-	member, appErr := p.API.GetChannelMember(channelID, userID)
-	require.Nil(t, appErr)
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		member, appErr := p.API.GetChannelMember(channelID, userID)
+		require.Nil(t, appErr)
 
-	assert.Equal(t, "true", member.NotifyProps[NotifyPropAutomuted])
-	assert.Equal(t, model.ChannelMarkUnreadMention, member.NotifyProps[model.MarkUnreadNotifyProp])
+		assert.Equal(t, "true", member.NotifyProps[NotifyPropAutomuted])
+		assert.Equal(t, model.ChannelMarkUnreadMention, member.NotifyProps[model.MarkUnreadNotifyProp])
+	}, 1*time.Second, 10*time.Millisecond)
 }
 
 func assertChannelNotAutomuted(t *testing.T, p *Plugin, channelID, userID string) {
 	t.Helper()
 
-	member, appErr := p.API.GetChannelMember(channelID, userID)
-	require.Nil(t, appErr)
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		member, appErr := p.API.GetChannelMember(channelID, userID)
+		require.Nil(t, appErr)
 
-	if _, ok := member.NotifyProps[NotifyPropAutomuted]; ok {
-		assert.Equal(t, "false", member.NotifyProps[NotifyPropAutomuted])
-	}
-	assert.Equal(t, model.ChannelMarkUnreadAll, member.NotifyProps[model.MarkUnreadNotifyProp])
+		if _, ok := member.NotifyProps[NotifyPropAutomuted]; ok {
+			assert.Equal(t, "false", member.NotifyProps[NotifyPropAutomuted])
+		}
+		assert.Equal(t, model.ChannelMarkUnreadAll, member.NotifyProps[model.MarkUnreadNotifyProp])
+	}, 1*time.Second, 10*time.Millisecond)
 }
 
-func mockUserConnected(p *Plugin, userID string) {
-	p.store.(*storemocks.Store).On("GetTokenForMattermostUser", userID).Return(&fakeToken, nil)
-}
+func assertChannelManuallyMuted(t *testing.T, p *Plugin, channelID, userID string) {
+	t.Helper()
 
-func mockUserNotConnected(p *Plugin, userID string) {
-	p.store.(*storemocks.Store).On("GetTokenForMattermostUser", userID).Return(nil, sql.ErrNoRows)
-}
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		member, appErr := p.API.GetChannelMember(channelID, userID)
+		require.Nil(t, appErr)
 
-// func setPrimaryPlatform(p *Plugin, userID string, value string) {
-// 	_ = p.API.UpdatePreferencesForUser(userID, []model.Preference{{
-// 		UserId:   userID,
-// 		Category: PreferenceCategoryPlugin,
-// 		Name:     PreferenceNamePlatform,
-// 		Value:    value,
-// 	}})
-// }
-
-func mockLinkedChannel(p *Plugin, channel *model.Channel) {
-	link := &storemodels.ChannelLink{
-		MattermostChannelID: channel.Id,
-	}
-	p.store.(*storemocks.Store).On("GetLinkByChannelID", channel.Id).Return(link, nil)
-	p.store.(*storemocks.Store).On("CheckEnabledTeamByTeamID", channel.TeamId).Return(true)
-}
-
-func mockUnlinkedChannel(p *Plugin, channel *model.Channel) {
-	p.store.(*storemocks.Store).On("GetLinkByChannelID", channel.Id).Return(nil, sql.ErrNoRows)
+		assert.Equal(t, "", member.NotifyProps[NotifyPropAutomuted])
+		assert.Equal(t, model.ChannelMarkUnreadMention, member.NotifyProps[model.MarkUnreadNotifyProp])
+	}, 1*time.Second, 10*time.Millisecond)
 }

--- a/server/automute_user_connect_test.go
+++ b/server/automute_user_connect_test.go
@@ -2,30 +2,33 @@ package main
 
 import (
 	"testing"
+	"time"
 
+	"github.com/mattermost/mattermost-plugin-msteams/server/store/storemodels"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 func TestUpdateAutomutingOnUserConnect(t *testing.T) {
+	th := setupTestHelper(t)
+
 	setup := func(t *testing.T) (*Plugin, *model.User, *model.Channel) {
 		t.Helper()
+		th.Reset(t)
 
-		p := newAutomuteTestPlugin(t)
+		team := th.SetupTeam(t)
 
-		user := &model.User{Id: model.NewId()}
-		mockUserNotConnected(p, user.Id)
+		user := th.SetupUser(t, team)
 
-		channel, _ := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
-		_, appErr := p.API.AddUserToChannel(channel.Id, user.Id, "")
-		require.Nil(t, appErr)
-		mockLinkedChannel(p, channel)
+		channel := th.SetupPublicChannel(t, team, WithMembers(user))
+		th.LinkChannel(t, team, channel, user)
 
-		assertChannelNotAutomuted(t, p, channel.Id, user.Id)
+		assertChannelNotAutomuted(t, th.p, channel.Id, user.Id)
 
-		return p, user, channel
+		return th.p, user, channel
 	}
 
 	t.Run("should do nothing when a user connects without their primary platform set", func(t *testing.T) {
@@ -118,20 +121,30 @@ func TestUpdateAutomutingOnUserConnect(t *testing.T) {
 }
 
 func TestUpdateAutomutingOnUserDisconnect(t *testing.T) {
+	th := setupTestHelper(t)
+	team := th.SetupTeam(t)
+
 	setup := func(t *testing.T) (*Plugin, *model.User, *model.Channel) {
 		t.Helper()
+		th.Reset(t)
 
-		p := newAutomuteTestPlugin(t)
+		user := th.SetupUser(t, team)
+		err := th.p.store.SetUserInfo(user.Id, "team_user_id", &oauth2.Token{AccessToken: "token", Expiry: time.Now().Add(10 * time.Minute)})
+		require.NoError(t, err)
 
-		user := &model.User{Id: model.NewId()}
-		mockUserConnected(p, user.Id)
+		linkedChannel := th.SetupPublicChannel(t, team, WithMembers(user))
 
-		channel, _ := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
-		_, appErr := p.API.AddUserToChannel(channel.Id, user.Id, "")
-		require.Nil(t, appErr)
-		mockLinkedChannel(p, channel)
+		channelLink := storemodels.ChannelLink{
+			MattermostTeamID:    team.Id,
+			MattermostChannelID: linkedChannel.Id,
+			MSTeamsTeam:         model.NewId(),
+			MSTeamsChannel:      model.NewId(),
+			Creator:             user.Id,
+		}
+		err = th.p.store.StoreChannelLink(&channelLink)
+		require.NoError(t, err)
 
-		return p, user, channel
+		return th.p, user, linkedChannel
 	}
 
 	t.Run("should disable automute when a user disconnects who previously had automuting enabled", func(t *testing.T) {
@@ -199,10 +212,7 @@ func TestUpdateAutomutingOnUserDisconnect(t *testing.T) {
 	t.Run("should not unmute a manually muted unlinked channel when a user disconnects", func(t *testing.T) {
 		p, user, _ := setup(t)
 
-		unlinkedChannel, _ := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
-		_, appErr := p.API.AddUserToChannel(unlinkedChannel.Id, user.Id, "")
-		require.Nil(t, appErr)
-		mockUnlinkedChannel(p, unlinkedChannel)
+		unlinkedChannel := th.SetupPublicChannel(t, team, WithMembers(user))
 
 		p.PreferencesHaveChanged(&plugin.Context{}, []model.Preference{
 			{

--- a/server/bot_messages.go
+++ b/server/bot_messages.go
@@ -88,3 +88,21 @@ func (p *Plugin) NotifyUpdatedAttachmentsNotSupportedFromTeams(post *model.Post)
 		p.GetAPI().LogWarn("Failed to notify channel of skipped attachment", "channel_id", post.ChannelId, "post_id", post.Id, "error", appErr)
 	}
 }
+
+func (p *Plugin) notifyUserConnected(userID string) {
+	if err := p.botSendDirectMessage(userID, "Welcome to Mattermost for Microsoft Teams! Your conversations with MS Teams users are now synchronized."); err != nil {
+		p.GetAPI().LogWarn("Failed to notify user connected", "user_id", userID, "error", err)
+	}
+}
+
+func (p *Plugin) notifyUserMattermostPrimary(userID string) {
+	if err := p.botSendDirectMessage(userID, "You’ve chosen Mattermost as your primary platform: you’ll receive Microsoft Teams messages and notifications in Mattermost. Consider [disabling MS Teams notifications](https://support.microsoft.com/en-us/office/manage-notifications-in-microsoft-teams-1cc31834-5fe5-412b-8edb-43fecc78413d) to avoid duplicated notifications."); err != nil {
+		p.GetAPI().LogWarn("Failed to notify user is Mattermost primary", "user_id", userID, "error", err)
+	}
+}
+
+func (p *Plugin) notifyUserTeamsPrimary(userID string) {
+	if err := p.botSendDirectMessage(userID, "You’ve chosen Microsoft Teams as your primary platform: your Mattermost notifications for DMs and GMs are muted, and you’ll receive chats from Mattermost in Microsoft Teams."); err != nil {
+		p.GetAPI().LogWarn("Failed to notify user is Teams primary", "user_id", userID, "error", err)
+	}
+}

--- a/server/bot_messages.go
+++ b/server/bot_messages.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/pkg/errors"
+)
+
+func (p *Plugin) botSendDirectMessage(userID, message string) error {
+	channel, err := p.apiClient.Channel.GetDirect(userID, p.userID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get bot DM channel with user_id %s", userID)
+	}
+
+	return p.apiClient.Post.CreatePost(&model.Post{
+		Message:   message,
+		UserId:    p.userID,
+		ChannelId: channel.Id,
+	})
+}
+
+func (p *Plugin) handlePromptForConnection(userID, channelID string) {
+	message := fmt.Sprintf("[Click here to connect your account](%s).", p.GetURL()+"/connect")
+	p.sendBotEphemeralPost(userID, channelID, "Some users in this conversation rely on Microsoft Teams to receive your messages, but your account isn't connected. "+message)
+}
+
+func (p *Plugin) notifyUserDisconnected(userID string) {
+	channel, appErr := p.API.GetDirectChannel(userID, p.GetBotUserID())
+	if appErr != nil {
+		p.API.LogWarn("Unable to get direct channel for send message to user", "user_id", userID, "error", appErr.Error())
+		return
+	}
+
+	connectURL := p.GetURL() + "/connect"
+	_, appErr = p.API.CreatePost(&model.Post{
+		UserId:    p.GetBotUserID(),
+		ChannelId: channel.Id,
+		Message:   "Your connection to Microsoft Teams has been lost. " + fmt.Sprintf("[Click here to reconnect your account](%s).", connectURL),
+	})
+	if appErr != nil {
+		p.API.LogWarn("Unable to send direct message to user", "user_id", userID, "error", appErr.Error())
+	}
+}
+
+func (p *Plugin) NotifyFileAttachmentError(userID, channelID string) {
+	_ = p.GetAPI().SendEphemeralPost(userID, &model.Post{
+		ChannelId: channelID,
+		UserId:    p.GetBotUserID(),
+		Message:   "Some images could not be delivered because they exceeded the maximum resolution and/or size allowed.",
+	})
+}
+
+func (p *Plugin) notifyAttachmentsNotSupportedFromMattermost(post *model.Post) {
+	_, appErr := p.GetAPI().CreatePost(&model.Post{
+		ChannelId: post.ChannelId,
+		UserId:    p.GetBotUserID(),
+		Message:   "Attachments sent from Mattermost aren't yet delivered to Microsoft Teams.",
+		CreateAt:  post.CreateAt,
+	})
+	if appErr != nil {
+		p.GetAPI().LogWarn("Failed to notify channel of skipped attachment", "channel_id", post.ChannelId, "post_id", post.Id, "error", appErr)
+	}
+}
+
+func (p *Plugin) NotifyAttachmentsNotSupportedFromTeams(post *model.Post) {
+	_, appErr := p.GetAPI().CreatePost(&model.Post{
+		ChannelId: post.ChannelId,
+		UserId:    p.GetBotUserID(),
+		Message:   "Attachments sent from Microsoft Teams aren't delivered to Mattermost.",
+		// Anchor the post immediately after (never before) the post that was created.
+		CreateAt: post.CreateAt + 1,
+	})
+	if appErr != nil {
+		p.GetAPI().LogWarn("Failed to notify channel of skipped attachment", "channel_id", post.ChannelId, "post_id", post.Id, "error", appErr)
+	}
+}
+
+func (p *Plugin) NotifyUpdatedAttachmentsNotSupportedFromTeams(post *model.Post) {
+	_, appErr := p.GetAPI().CreatePost(&model.Post{
+		ChannelId: post.ChannelId,
+		UserId:    p.GetBotUserID(),
+		Message:   "Attachments added to an existing post in Microsoft Teams aren't delivered to Mattermost.",
+		// Anchor the post immediately after (never before) the post that was edited.
+		CreateAt: post.CreateAt + 1,
+	})
+	if appErr != nil {
+		p.GetAPI().LogWarn("Failed to notify channel of skipped attachment", "channel_id", post.ChannelId, "post_id", post.Id, "error", appErr)
+	}
+}

--- a/server/connect.go
+++ b/server/connect.go
@@ -9,19 +9,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (p *Plugin) botSendDirectMessage(userID, message string) error {
-	channel, err := p.apiClient.Channel.GetDirect(userID, p.userID)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get bot DM channel with user_id %s", userID)
-	}
-
-	return p.apiClient.Post.CreatePost(&model.Post{
-		Message:   message,
-		UserId:    p.userID,
-		ChannelId: channel.Id,
-	})
-}
-
 func (p *Plugin) MaybeSendInviteMessage(userID string) (bool, error) {
 	if p.getConfiguration().ConnectedUsersInvitePoolSize == 0 {
 		// connection invites disabled

--- a/server/handlers/getters_test.go
+++ b/server/handlers/getters_test.go
@@ -67,6 +67,9 @@ func (pm *pluginMock) GetSelectiveSync() bool { return pm.selectiveSync }
 func (pm *pluginMock) ChatSpansPlatforms(channelID string) (bool, *model.AppError) {
 	return true, nil
 }
+func (pm *pluginMock) NotifyFileAttachmentError(userID, channelID string)             {}
+func (pm *pluginMock) NotifyUpdatedAttachmentsNotSupportedFromTeams(post *model.Post) {}
+func (pm *pluginMock) NotifyAttachmentsNotSupportedFromTeams(post *model.Post)        {}
 
 func newTestHandler() *ActivityHandler {
 	return New(&pluginMock{

--- a/server/handlers/mocks/PluginIface.go
+++ b/server/handlers/mocks/PluginIface.go
@@ -321,6 +321,21 @@ func (_m *PluginIface) IsRemoteUser(user *model.User) bool {
 	return r0
 }
 
+// NotifyAttachmentsNotSupportedFromTeams provides a mock function with given fields: post
+func (_m *PluginIface) NotifyAttachmentsNotSupportedFromTeams(post *model.Post) {
+	_m.Called(post)
+}
+
+// NotifyFileAttachmentError provides a mock function with given fields: userID, channelID
+func (_m *PluginIface) NotifyFileAttachmentError(userID string, channelID string) {
+	_m.Called(userID, channelID)
+}
+
+// NotifyUpdatedAttachmentsNotSupportedFromTeams provides a mock function with given fields: post
+func (_m *PluginIface) NotifyUpdatedAttachmentsNotSupportedFromTeams(post *model.Post) {
+	_m.Called(post)
+}
+
 type mockConstructorTestingTNewPluginIface interface {
 	mock.TestingT
 	Cleanup(func())

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -566,15 +566,7 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post, c
 			p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, "", true)
 		}
 	} else if len(post.FileIds) > 0 {
-		_, appErr := p.API.CreatePost(&model.Post{
-			ChannelId: post.ChannelId,
-			UserId:    p.GetBotUserID(),
-			Message:   "Attachments sent from Mattermost aren't yet delivered to Microsoft Teams.",
-			CreateAt:  post.CreateAt,
-		})
-		if appErr != nil {
-			p.API.LogWarn("Failed to notify channel of skipped attachment", "channel_id", post.ChannelId, "post_id", post.Id, "error", appErr)
-		}
+		p.notifyAttachmentsNotSupportedFromMattermost(post)
 	}
 
 	md := markdown.New(markdown.XHTMLOutput(true), markdown.Typographer(false))
@@ -605,11 +597,6 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post, c
 		}
 	}
 	return newMessage.ID, nil
-}
-
-func (p *Plugin) handlePromptForConnection(userID, channelID string) {
-	message := fmt.Sprintf("[Click here to connect your account](%s).", p.GetURL()+"/connect")
-	p.sendBotEphemeralPost(userID, channelID, "Some users in this conversation rely on Microsoft Teams to receive your messages, but your account isn't connected. "+message)
 }
 
 func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Post) (string, error) {
@@ -660,15 +647,7 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 			p.GetMetrics().ObserveFile(metrics.ActionCreated, metrics.ActionSourceMattermost, "", false)
 		}
 	} else if len(post.FileIds) > 0 {
-		_, appErr := p.API.CreatePost(&model.Post{
-			ChannelId: post.ChannelId,
-			UserId:    p.GetBotUserID(),
-			Message:   "Attachments sent from Mattermost aren't yet delivered to Microsoft Teams.",
-			CreateAt:  post.CreateAt,
-		})
-		if appErr != nil {
-			p.API.LogWarn("Failed to notify channel of skipped attachment", "channel_id", channelID, "post_id", post.Id, "error", appErr)
-		}
+		p.notifyAttachmentsNotSupportedFromMattermost(post)
 	}
 
 	md := markdown.New(markdown.XHTMLOutput(true), markdown.Typographer(false))

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -176,21 +176,8 @@ func (p *Plugin) OnDisconnectedTokenHandler(userID string) {
 		p.API.LogWarn("Unable clean invalid token for the user", "user_id", userID, "error", err2.Error())
 		return
 	}
-	channel, appErr := p.API.GetDirectChannel(userID, p.GetBotUserID())
-	if appErr != nil {
-		p.API.LogWarn("Unable to get direct channel for send message to user", "user_id", userID, "error", appErr.Error())
-		return
-	}
 
-	connectURL := p.GetURL() + "/connect"
-	_, appErr = p.API.CreatePost(&model.Post{
-		UserId:    p.GetBotUserID(),
-		ChannelId: channel.Id,
-		Message:   "Your connection to Microsoft Teams has been lost. " + fmt.Sprintf("[Click here to reconnect your account](%s).", connectURL),
-	})
-	if appErr != nil {
-		p.API.LogWarn("Unable to send direct message to user", "user_id", userID, "error", appErr.Error())
-	}
+	p.notifyUserDisconnected(userID)
 }
 
 func (p *Plugin) GetClientForUser(userID string) (msteams.Client, error) {


### PR DESCRIPTION
#### Summary
This PR welcomes users when the connect with a message from the bot:

![CleanShot 2024-04-04 at 17 54 18@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/670a4f0a-c565-4079-9210-52f9a7ee4821)

When they choose Mattermost or Microsoft Teams during onboarding (or anytime afterwards from the user preferences pane), they are notified as such:

**Choosing Mattermost**
![CleanShot 2024-04-04 at 17 54 39@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/85ce9863-206d-4b83-8b72-4f27cb5b517c)

**Choosing Teams**
![CleanShot 2024-04-04 at 17 54 56@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/bfaa4849-a4c2-484c-9861-bd249a2d642b)

##### Other Changes

This pull request depends on https://github.com/mattermost/mattermost-plugin-msteams/pull/563 for updated unit tests. (Do not merge until that is merged to `main`.) To test the above, I took @hmhealey's excellent mocked unit tests and modified them to fit into the new "mock-free" testing paradigm. (That's the bulk of this PR -- sorry for the noise! This will all get easier once we've expunged the mock tests.)

I also took the opportunity to centralize most bot messages into a `bot_messages.go`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57494