### PR TITLE
Set EmailVerified to true for all remote users during migration

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -580,7 +580,6 @@ func (p *Plugin) executePromoteUserCommand(args *model.CommandArgs, parameters [
 
 	user.RemoteId = nil
 	user.Username = newUsername
-	user.EmailVerified = true
 	_, appErr = p.API.UpdateUser(user)
 	if appErr != nil {
 		p.API.LogWarn("Unable to update the user during promotion", "user_id", user.Id, "error", appErr.Error())

--- a/server/handlers/getters.go
+++ b/server/handlers/getters.go
@@ -111,11 +111,12 @@ func (ah *ActivityHandler) getOrCreateSyntheticUser(user *clientmodels.User, cre
 		username := "msteams_" + slug.Make(userDisplayName)
 
 		newMMUser := &model.User{
-			Username:  username,
-			FirstName: userDisplayName,
-			Email:     user.Mail,
-			Password:  ah.plugin.GenerateRandomPassword(),
-			RemoteId:  &remoteID,
+			Username:      username,
+			FirstName:     userDisplayName,
+			Email:         user.Mail,
+			Password:      ah.plugin.GenerateRandomPassword(),
+			RemoteId:      &remoteID,
+			EmailVerified: true,
 		}
 		newMMUser.SetDefaultNotifications()
 		newMMUser.NotifyProps[model.EmailNotifyProp] = "false"

--- a/server/handlers/getters_test.go
+++ b/server/handlers/getters_test.go
@@ -123,6 +123,9 @@ func TestGetOrCreateSyntheticUser(t *testing.T) {
 					if user.Email != testutils.GetTestEmail() {
 						return false
 					}
+					if !user.EmailVerified {
+						return false
+					}
 					return true
 				})).Return(&model.User{Id: "new-user-id"}, nil).Times(1)
 				api.On("UpdatePreferencesForUser", "new-user-id", mock.MatchedBy(func(preferences model.Preferences) bool {

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -26,7 +26,6 @@ import (
 func (p *Plugin) UserWillLogIn(_ *plugin.Context, user *model.User) string {
 	if p.IsRemoteUser(user) && p.getConfiguration().AutomaticallyPromoteSyntheticUsers {
 		*user.RemoteId = ""
-		user.EmailVerified = true
 		if _, appErr := p.API.UpdateUser(user); appErr != nil {
 			p.API.LogWarn("Unable to promote synthetic user", "user_id", user.Id, "error", appErr.Error())
 			return "Unable to promote synthetic user"

--- a/server/message_hooks_test.go
+++ b/server/message_hooks_test.go
@@ -2825,7 +2825,7 @@ func TestUserWillLogin(t *testing.T) {
 			AutomaticallyPromoteSyntheticUsers: true,
 			SetupAPI: func(api *plugintest.API) {
 				api.On("UpdateUser", mock.MatchedBy(func(user *model.User) bool {
-					return *user.RemoteId == ""
+					return !user.IsRemote()
 				})).Once().Return(nil, nil)
 				api.On("LogInfo", "Promoted synthetic user", "user_id", testutils.GetID()).Once()
 			},
@@ -2844,7 +2844,7 @@ func TestUserWillLogin(t *testing.T) {
 			AutomaticallyPromoteSyntheticUsers: true,
 			SetupAPI: func(api *plugintest.API) {
 				api.On("UpdateUser", mock.MatchedBy(func(user *model.User) bool {
-					return *user.RemoteId == ""
+					return !user.IsRemote()
 				})).Once().Return(nil, model.NewAppError("UpdateUser", "err from test", nil, "", 500))
 				api.On("LogWarn", "Failed to promote synthetic user", "user_id", testutils.GetID(), "err", "err from test").Once()
 			},

--- a/server/message_hooks_test.go
+++ b/server/message_hooks_test.go
@@ -2819,22 +2819,13 @@ func TestUserWillLogin(t *testing.T) {
 		{
 			Name: "Autopromotion works",
 			User: &model.User{
-				Id:            testutils.GetID(),
-				EmailVerified: false,
+				Id: testutils.GetID(),
 			},
 			UserIsRemote:                       true,
 			AutomaticallyPromoteSyntheticUsers: true,
 			SetupAPI: func(api *plugintest.API) {
 				api.On("UpdateUser", mock.MatchedBy(func(user *model.User) bool {
-					if user.EmailVerified == false {
-						return false
-					}
-
-					if *user.RemoteId != "" {
-						return false
-					}
-
-					return true
+					return *user.RemoteId == ""
 				})).Once().Return(nil, nil)
 				api.On("LogInfo", "Promoted synthetic user", "user_id", testutils.GetID()).Once()
 			},
@@ -2847,22 +2838,13 @@ func TestUserWillLogin(t *testing.T) {
 		{
 			Name: "UpdateUser failed during autopromotion",
 			User: &model.User{
-				Id:            testutils.GetID(),
-				EmailVerified: false,
+				Id: testutils.GetID(),
 			},
 			UserIsRemote:                       true,
 			AutomaticallyPromoteSyntheticUsers: true,
 			SetupAPI: func(api *plugintest.API) {
 				api.On("UpdateUser", mock.MatchedBy(func(user *model.User) bool {
-					if user.EmailVerified == false {
-						return false
-					}
-
-					if *user.RemoteId != "" {
-						return false
-					}
-
-					return true
+					return *user.RemoteId == ""
 				})).Once().Return(nil, model.NewAppError("UpdateUser", "err from test", nil, "", 500))
 				api.On("LogWarn", "Failed to promote synthetic user", "user_id", testutils.GetID(), "err", "err from test").Once()
 			},
@@ -2873,8 +2855,7 @@ func TestUserWillLogin(t *testing.T) {
 		{
 			Name: "No autopromotion",
 			User: &model.User{
-				Id:            testutils.GetID(),
-				EmailVerified: false,
+				Id: testutils.GetID(),
 			},
 			UserIsRemote:                       true,
 			AutomaticallyPromoteSyntheticUsers: false,

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -747,11 +747,6 @@ func (p *Plugin) syncUsers() {
 					shouldUpdate = true
 				}
 
-				if !mmUser.EmailVerified {
-					mmUser.EmailVerified = true
-					shouldUpdate = true
-				}
-
 				if shouldUpdate {
 					for {
 						p.API.LogInfo("Updating user profile", "user_id", mmUser.Id, "teams_user_id", msUser.ID)

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -376,8 +376,7 @@ func TestSyncUsers(t *testing.T) {
 				}, nil).Times(1)
 				api.On("GetUser", testutils.GetUserID()).Return(testutils.GetRemoteUser(model.SystemAdminRoleId, "test@test.com", "remote-id"), nil).Once()
 				api.On("UpdateUser", mock.MatchedBy(func(u *model.User) bool {
-					return u.EmailVerified == true &&
-						u.FirstName == "mockDisplayName" &&
+					return u.FirstName == "mockDisplayName" &&
 						u.Username == "msteams_mockdisplayname"
 				})).Return(&model.User{
 					Id: testutils.GetID(),

--- a/server/store/sqlstore/migrations.go
+++ b/server/store/sqlstore/migrations.go
@@ -17,6 +17,18 @@ func (s *SQLStore) runMigrationRemoteID(remoteID string) error {
 	return err
 }
 
+func (s *SQLStore) runSetEmailVerifiedToTrueForRemoteUsers(remoteID string) error {
+	_, err := s.getQueryBuilder().
+		Update("Users").
+		Set("EmailVerified", true).
+		Where(sq.And{
+			sq.Eq{"RemoteID": remoteID},
+			sq.Eq{"EmailVerified": false},
+		}).Exec()
+
+	return err
+}
+
 const (
 	DedupScoreDefault      byte = 0
 	DedupScoreNotSynthetic byte = 1

--- a/server/store/sqlstore/store.go
+++ b/server/store/sqlstore/store.go
@@ -116,6 +116,10 @@ func (s *SQLStore) Init(remoteID string) error {
 		if err := s.runMigrationRemoteID(remoteID); err != nil {
 			return err
 		}
+
+		if err := s.runSetEmailVerifiedToTrueForRemoteUsers(remoteID); err != nil {
+			return err
+		}
 	}
 
 	exist, err := s.indexExist(usersTableName, "idx_msteamssync_users_msteamsuserid_unq")


### PR DESCRIPTION
#### Summary
`UpdateUser` ignores the `EmailVerified`, so our `UpdateUser` calls have no effect and we would try to do it at every `syncUser`. In addition, doing the Uodate one by one was quite hurtful.

This fixes the issue by migrating all necessary users in one query during a migration.

#### Ticket Link
N/A
