### PR TITLE
MM-57565 - Set root id if it exists on attachment sync warning

### DIFF
--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -568,9 +568,9 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post, c
 	} else if len(post.FileIds) > 0 {
 		_, appErr := p.API.CreatePost(&model.Post{
 			ChannelId: post.ChannelId,
+			RootId:    post.RootId,
 			UserId:    p.GetBotUserID(),
 			Message:   "Attachments sent from Mattermost aren't yet delivered to Microsoft Teams.",
-			CreateAt:  post.CreateAt,
 		})
 		if appErr != nil {
 			p.API.LogWarn("Failed to notify channel of skipped attachment", "channel_id", post.ChannelId, "post_id", post.Id, "error", appErr)
@@ -662,9 +662,9 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 	} else if len(post.FileIds) > 0 {
 		_, appErr := p.API.CreatePost(&model.Post{
 			ChannelId: post.ChannelId,
+			RootId:    post.RootId,
 			UserId:    p.GetBotUserID(),
 			Message:   "Attachments sent from Mattermost aren't yet delivered to Microsoft Teams.",
-			CreateAt:  post.CreateAt,
 		})
 		if appErr != nil {
 			p.API.LogWarn("Failed to notify channel of skipped attachment", "channel_id", channelID, "post_id", post.Id, "error", appErr)


### PR DESCRIPTION


#### Summary
Set the rootID for the new post to the existing posts root id. Result is if null, new post displays in center section and if a reply it will appear in the thread list.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-57565

<img width="1643" alt="Screenshot 2024-04-15 at 6 24 46 PM" src="https://github.com/mattermost/mattermost-plugin-msteams/assets/12704875/bbdc5588-49c6-4a60-be4d-4019b467dc85">
