### PR TITLE
Track status_code as part of the MSGraphClient method duration

### DIFF
--- a/server/api_test.go
+++ b/server/api_test.go
@@ -522,7 +522,7 @@ func TestAutocompleteTeams(t *testing.T) {
 				uclient.On("ListTeams").Return(nil, errors.New("unable to get the teams list")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.ListTeams", "false", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.ListTeams", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedResult: []model.AutocompleteListItem{},
 		},
@@ -548,7 +548,7 @@ func TestAutocompleteTeams(t *testing.T) {
 				}, nil).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.ListTeams", "true", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.ListTeams", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedResult: []model.AutocompleteListItem{
 				{
@@ -630,7 +630,7 @@ func TestAutocompleteChannels(t *testing.T) {
 				uclient.On("ListChannels", "mockData-3").Return(nil, errors.New("unable to get the channels list")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.ListChannels", "false", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.ListChannels", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedResult: []model.AutocompleteListItem{},
 		},
@@ -657,7 +657,7 @@ func TestAutocompleteChannels(t *testing.T) {
 				}, nil).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.ListChannels", "true", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.ListChannels", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedResult: []model.AutocompleteListItem{
 				{

--- a/server/message_hooks_test.go
+++ b/server/message_hooks_test.go
@@ -139,7 +139,7 @@ func TestReactionHasBeenAdded(t *testing.T) {
 				uclient.On("SetReaction", "ms-teams-team-id", "ms-teams-channel-id", "", "ms-teams-id", testutils.GetID(), mock.AnythingOfType("string")).Return(nil, errors.New("unable to set the reaction")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.SetReaction", "false", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.SetReaction", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 		},
 		{
@@ -166,7 +166,7 @@ func TestReactionHasBeenAdded(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveReaction", metrics.ReactionSetAction, metrics.ActionSourceMattermost, false).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SetReaction", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SetReaction", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 		{
@@ -193,7 +193,7 @@ func TestReactionHasBeenAdded(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveReaction", metrics.ReactionSetAction, metrics.ActionSourceMattermost, false).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SetReaction", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SetReaction", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 	} {
@@ -338,7 +338,7 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 				uclient.On("UnsetReaction", "mockTeamsTeamID", "mockTeamsChannelID", "", "", testutils.GetID(), mock.AnythingOfType("string")).Return(nil, errors.New("unable to unset the reaction")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetReaction", "false", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetReaction", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 		},
 		{
@@ -372,7 +372,7 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveReaction", metrics.ReactionUnsetAction, metrics.ActionSourceMattermost, false).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetReaction", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetReaction", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 		{
@@ -406,7 +406,7 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveReaction", metrics.ReactionUnsetAction, metrics.ActionSourceMattermost, false).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetReaction", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetReaction", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 	} {
@@ -482,8 +482,8 @@ func TestMessageHasBeenUpdated(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveMessage", metrics.ActionUpdated, metrics.ActionSourceMattermost, true).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateChatMessage", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateChatMessage", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 		{
@@ -562,7 +562,7 @@ func TestMessageHasBeenUpdated(t *testing.T) {
 				uclient.On("CreateOrGetChatForUsers", mock.AnythingOfType("[]string")).Return(mockChat, nil).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 		{
@@ -587,7 +587,7 @@ func TestMessageHasBeenUpdated(t *testing.T) {
 				uclient.On("CreateOrGetChatForUsers", mock.AnythingOfType("[]string")).Return(nil, errors.New("unable to create or get chat for users")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "false", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 		},
 		{
@@ -624,7 +624,7 @@ func TestMessageHasBeenUpdated(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveMessage", metrics.ActionUpdated, metrics.ActionSourceMattermost, false).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateMessage", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateMessage", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 		{
@@ -660,7 +660,7 @@ func TestMessageHasBeenUpdated(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveMessage", metrics.ActionUpdated, metrics.ActionSourceMattermost, false).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateMessage", "false", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateMessage", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 		},
 		{
@@ -696,7 +696,7 @@ func TestMessageHasBeenUpdated(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveMessage", metrics.ActionUpdated, metrics.ActionSourceMattermost, false).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateMessage", "false", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateMessage", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 		},
 	} {
@@ -788,8 +788,8 @@ func TestSetChatReaction(t *testing.T) {
 				uclient.On("SetChatReaction", testutils.GetChatID(), "mockTeamsMessageID", testutils.GetID(), ":mockEmojiName:").Return(nil, errors.New("unable to set the chat reaction")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.SetChatReaction", "false", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.SetChatReaction", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "unable to set the chat reaction",
 			UpdateRequired:  true,
@@ -812,8 +812,8 @@ func TestSetChatReaction(t *testing.T) {
 				uclient.On("GetChatMessage", testutils.GetChatID(), "mockTeamsMessageID").Return(mockChatMessage, nil).Once()
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChatMessage", "true", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChatMessage", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 		{
@@ -835,8 +835,8 @@ func TestSetChatReaction(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveReaction", metrics.ReactionSetAction, metrics.ActionSourceMattermost, true).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SetChatReaction", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SetChatReaction", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			UpdateRequired: true,
 		},
@@ -859,8 +859,8 @@ func TestSetChatReaction(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveReaction", metrics.ReactionSetAction, metrics.ActionSourceMattermost, true).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SetChatReaction", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SetChatReaction", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			UpdateRequired: true,
 		},
@@ -943,7 +943,7 @@ func TestSetReaction(t *testing.T) {
 				uclient.On("SetReaction", "mockTeamsTeamID", "mockTeamsChannelID", "", "", testutils.GetID(), ":mockName:").Return(nil, errors.New("unable to set the reaction")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.SetReaction", "false", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.SetReaction", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "unable to set the reaction",
 		},
@@ -964,7 +964,7 @@ func TestSetReaction(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveReaction", metrics.ReactionSetAction, metrics.ActionSourceMattermost, false).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SetReaction", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SetReaction", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 	} {
@@ -1061,8 +1061,8 @@ func TestUnsetChatReaction(t *testing.T) {
 				uclient.On("UnsetChatReaction", testutils.GetChatID(), "mockTeamsMessageID", testutils.GetID(), ":mockEmojiName:").Return(nil, errors.New("unable to unset the chat reaction")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetChatReaction", "false", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetChatReaction", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "unable to unset the chat reaction",
 		},
@@ -1085,8 +1085,8 @@ func TestUnsetChatReaction(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveReaction", metrics.ReactionUnsetAction, metrics.ActionSourceMattermost, true).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetChatReaction", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetChatReaction", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 		{
@@ -1108,8 +1108,8 @@ func TestUnsetChatReaction(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveReaction", metrics.ReactionUnsetAction, metrics.ActionSourceMattermost, true).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetChatReaction", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetChatReaction", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 	} {
@@ -1190,7 +1190,7 @@ func TestUnsetReaction(t *testing.T) {
 				uclient.On("UnsetReaction", "mockTeamsTeamID", "mockTeamsChannelID", "", "", testutils.GetID(), ":mockName:").Return(nil, errors.New("unable to unset the reaction")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetReaction", "false", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetReaction", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "unable to unset the reaction",
 		},
@@ -1210,7 +1210,7 @@ func TestUnsetReaction(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveReaction", metrics.ReactionUnsetAction, metrics.ActionSourceMattermost, false).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetReaction", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UnsetReaction", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 	} {
@@ -1346,7 +1346,7 @@ func TestSendChat(t *testing.T) {
 				uclient.On("CreateOrGetChatForUsers", mock.AnythingOfType("[]string")).Return(nil, errors.New("unable to create or get the chat")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "false", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedError: "unable to create or get the chat",
 		},
@@ -1376,10 +1376,10 @@ func TestSendChat(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveFile", metrics.ActionCreated, metrics.ActionSourceMattermost, "", true).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "false", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedError: "unable to send the chat",
 		},
@@ -1418,10 +1418,10 @@ func TestSendChat(t *testing.T) {
 				mockmetrics.On("ObserveFile", metrics.ActionCreated, metrics.ActionSourceMattermost, "", true).Times(1)
 				mockmetrics.On("ObserveMessage", metrics.ActionCreated, metrics.ActionSourceMattermost, true).Times(1)
 				mockmetrics.On("ObserveMessageDelay", metrics.ActionCreated, metrics.ActionSourceMattermost, true, mock.AnythingOfType("time.Duration")).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "mockMessageID",
 		},
@@ -1463,11 +1463,11 @@ func TestSendChat(t *testing.T) {
 				mockmetrics.On("ObserveFile", metrics.ActionCreated, metrics.ActionSourceMattermost, "", true).Times(1)
 				mockmetrics.On("ObserveMessage", metrics.ActionCreated, metrics.ActionSourceMattermost, true).Times(1)
 				mockmetrics.On("ObserveMessageDelay", metrics.ActionCreated, metrics.ActionSourceMattermost, true, mock.AnythingOfType("time.Duration")).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChatMessage", "false", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChatMessage", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "mockMessageID",
 		},
@@ -1501,9 +1501,9 @@ func TestSendChat(t *testing.T) {
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveMessage", metrics.ActionCreated, metrics.ActionSourceMattermost, true).Times(1)
 				mockmetrics.On("ObserveMessageDelay", metrics.ActionCreated, metrics.ActionSourceMattermost, true, mock.AnythingOfType("time.Duration")).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "mockMessageID",
 		},
@@ -1536,9 +1536,9 @@ func TestSendChat(t *testing.T) {
 				mockmetrics.On("ObserveFile", metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToGetMMData, true).Times(1)
 				mockmetrics.On("ObserveMessage", metrics.ActionCreated, metrics.ActionSourceMattermost, true).Times(1)
 				mockmetrics.On("ObserveMessageDelay", metrics.ActionCreated, metrics.ActionSourceMattermost, true, mock.AnythingOfType("time.Duration")).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "mockMessageID",
 		},
@@ -1572,9 +1572,9 @@ func TestSendChat(t *testing.T) {
 				mockmetrics.On("ObserveFile", metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToGetMMData, true).Times(1)
 				mockmetrics.On("ObserveMessage", metrics.ActionCreated, metrics.ActionSourceMattermost, true).Times(1)
 				mockmetrics.On("ObserveMessageDelay", metrics.ActionCreated, metrics.ActionSourceMattermost, true, mock.AnythingOfType("time.Duration")).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "mockMessageID",
 		},
@@ -1622,11 +1622,11 @@ func TestSendChat(t *testing.T) {
 				mockmetrics.On("ObserveFile", metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToUploadFileOnTeams, true).Times(1)
 				mockmetrics.On("ObserveMessage", metrics.ActionCreated, metrics.ActionSourceMattermost, true).Times(1)
 				mockmetrics.On("ObserveMessageDelay", metrics.ActionCreated, metrics.ActionSourceMattermost, true, mock.AnythingOfType("time.Duration")).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "false", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChatMessage", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "false", "0", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChatMessage", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "mockMessageID",
 		},
@@ -1665,10 +1665,10 @@ func TestSendChat(t *testing.T) {
 				mockmetrics.On("ObserveFile", metrics.ActionCreated, metrics.ActionSourceMattermost, "", true).Times(1)
 				mockmetrics.On("ObserveMessage", metrics.ActionCreated, metrics.ActionSourceMattermost, true).Times(1)
 				mockmetrics.On("ObserveMessageDelay", metrics.ActionCreated, metrics.ActionSourceMattermost, true, mock.AnythingOfType("time.Duration")).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendChat", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "mockMessageID",
 		},
@@ -1753,7 +1753,7 @@ func TestSend(t *testing.T) {
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveMessage", metrics.ActionCreated, metrics.ActionSourceMattermost, false).Times(1)
 				mockmetrics.On("ObserveMessageDelay", metrics.ActionCreated, metrics.ActionSourceMattermost, false, mock.AnythingOfType("time.Duration")).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendMessageWithAttachments", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendMessageWithAttachments", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "mockMessageID",
 		},
@@ -1782,7 +1782,7 @@ func TestSend(t *testing.T) {
 				mockmetrics.On("ObserveFile", metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToGetMMData, false).Times(1)
 				mockmetrics.On("ObserveMessage", metrics.ActionCreated, metrics.ActionSourceMattermost, false).Times(1)
 				mockmetrics.On("ObserveMessageDelay", metrics.ActionCreated, metrics.ActionSourceMattermost, false, mock.AnythingOfType("time.Duration")).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendMessageWithAttachments", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendMessageWithAttachments", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "mockMessageID",
 		},
@@ -1812,7 +1812,7 @@ func TestSend(t *testing.T) {
 				mockmetrics.On("ObserveFile", metrics.ActionCreated, metrics.ActionSourceMattermost, metrics.DiscardedReasonUnableToGetMMData, false).Times(1)
 				mockmetrics.On("ObserveMessage", metrics.ActionCreated, metrics.ActionSourceMattermost, false).Times(1)
 				mockmetrics.On("ObserveMessageDelay", metrics.ActionCreated, metrics.ActionSourceMattermost, false, mock.AnythingOfType("time.Duration")).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendMessageWithAttachments", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendMessageWithAttachments", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "mockMessageID",
 		},
@@ -1842,8 +1842,8 @@ func TestSend(t *testing.T) {
 				mockmetrics.On("ObserveFile", metrics.ActionCreated, metrics.ActionSourceMattermost, "", false).Times(1)
 				mockmetrics.On("ObserveMessage", metrics.ActionCreated, metrics.ActionSourceMattermost, false).Times(1)
 				mockmetrics.On("ObserveMessageDelay", metrics.ActionCreated, metrics.ActionSourceMattermost, false, mock.AnythingOfType("time.Duration")).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendMessageWithAttachments", "false", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendMessageWithAttachments", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedError: "unable to send message with attachments",
 		},
@@ -1880,8 +1880,8 @@ func TestSend(t *testing.T) {
 				mockmetrics.On("ObserveFile", metrics.ActionCreated, metrics.ActionSourceMattermost, "", false).Times(1)
 				mockmetrics.On("ObserveMessage", metrics.ActionCreated, metrics.ActionSourceMattermost, false).Times(1)
 				mockmetrics.On("ObserveMessageDelay", metrics.ActionCreated, metrics.ActionSourceMattermost, false, mock.AnythingOfType("time.Duration")).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendMessageWithAttachments", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendMessageWithAttachments", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "mockMessageID",
 		},
@@ -1918,8 +1918,8 @@ func TestSend(t *testing.T) {
 				mockmetrics.On("ObserveFile", metrics.ActionCreated, metrics.ActionSourceMattermost, "", false).Times(1)
 				mockmetrics.On("ObserveMessage", metrics.ActionCreated, metrics.ActionSourceMattermost, false).Times(1)
 				mockmetrics.On("ObserveMessageDelay", metrics.ActionCreated, metrics.ActionSourceMattermost, false, mock.AnythingOfType("time.Duration")).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", mock.AnythingOfType("float64")).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendMessageWithAttachments", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UploadFile", "true", "2XX", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.SendMessageWithAttachments", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedMessage: "mockMessageID",
 		},
@@ -2006,7 +2006,7 @@ func TestDelete(t *testing.T) {
 				uclient.On("DeleteMessage", "mockTeamsTeamID", testutils.GetChannelID(), "", "mockMSTeamsID").Return(errors.New("unable to delete the message")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteMessage", "false", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteMessage", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedError: "unable to delete the message",
 		},
@@ -2025,7 +2025,7 @@ func TestDelete(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveMessage", metrics.ActionDeleted, metrics.ActionSourceMattermost, false).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteMessage", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteMessage", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 	} {
@@ -2103,8 +2103,8 @@ func TestDeleteChat(t *testing.T) {
 				uclient.On("CreateOrGetChatForUsers", anyStringSlice).Return(mockChat, nil).Times(1)
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", anyFloat64).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteChatMessage", "true", anyFloat64).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", anyFloat64).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteChatMessage", "true", "2XX", anyFloat64).Once()
 			},
 			ExpectedError: "unable to get the post info",
 		},
@@ -2123,8 +2123,8 @@ func TestDeleteChat(t *testing.T) {
 				uclient.On("CreateOrGetChatForUsers", anyStringSlice).Return(mockChat, nil).Times(1)
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", anyFloat64).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteChatMessage", "true", anyFloat64).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", anyFloat64).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteChatMessage", "true", "2XX", anyFloat64).Once()
 			},
 			ExpectedError: "post not found",
 		},
@@ -2147,9 +2147,9 @@ func TestDeleteChat(t *testing.T) {
 				uclient.On("DeleteChatMessage", anyString, anyString, "mockMSTeamsID").Return(errors.New("unable to delete the message")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", anyFloat64).Once()
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteChatMessage", "true", anyFloat64).Once()
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteChatMessage", "false", anyFloat64).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", anyFloat64).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteChatMessage", "true", "2XX", anyFloat64).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteChatMessage", "false", "0", anyFloat64).Once()
 			},
 			ExpectedError: "unable to delete the message",
 		},
@@ -2172,10 +2172,10 @@ func TestDeleteChat(t *testing.T) {
 				uclient.On("DeleteChatMessage", anyString, anyString, "mockMSTeamsID").Return(nil).Times(1)
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", anyFloat64).Once()
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteChatMessage", "true", anyFloat64).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.CreateOrGetChatForUsers", "true", "2XX", anyFloat64).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteChatMessage", "true", "2XX", anyFloat64).Once()
 				mockmetrics.On("ObserveMessage", metrics.ActionDeleted, metrics.ActionSourceMattermost, true).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteChatMessage", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.DeleteChatMessage", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 	} {
@@ -2262,7 +2262,7 @@ func TestUpdate(t *testing.T) {
 				uclient.On("UpdateMessage", "mockTeamsTeamID", testutils.GetChannelID(), "", "mockMSTeamsID", "<p>mockMessage??????????</p>\n", []models.ChatMessageMentionable{}).Return(nil, errors.New("unable to update the message")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateMessage", "false", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateMessage", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedError:  "unable to update the message",
 			UpdateRequired: true,
@@ -2288,7 +2288,7 @@ func TestUpdate(t *testing.T) {
 				uclient.On("GetMessage", "mockTeamsTeamID", testutils.GetChannelID(), "mockMSTeamsID").Return(mockChannelMessage, nil).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.GetMessage", "true", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.GetMessage", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 		{
@@ -2313,7 +2313,7 @@ func TestUpdate(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveMessage", metrics.ActionUpdated, metrics.ActionSourceMattermost, false).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateMessage", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateMessage", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			UpdateRequired: true,
 		},
@@ -2339,7 +2339,7 @@ func TestUpdate(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveMessage", metrics.ActionUpdated, metrics.ActionSourceMattermost, false).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateMessage", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateMessage", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			UpdateRequired: true,
 		},
@@ -2430,7 +2430,7 @@ func TestUpdateChat(t *testing.T) {
 				uclient.On("UpdateChatMessage", "mockChatID", "mockTeamsTeamID", "<p>mockMessage??????????</p>\n", []models.ChatMessageMentionable{}).Return(nil, errors.New("unable to update the message")).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateChatMessage", "false", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateChatMessage", "false", "0", mock.AnythingOfType("float64")).Once()
 			},
 			ExpectedError:  "unable to update the message",
 			UpdateRequired: true,
@@ -2454,7 +2454,7 @@ func TestUpdateChat(t *testing.T) {
 				uclient.On("GetChatMessage", "mockChatID", "mockTeamsTeamID").Return(mockChatMessage, nil).Times(1)
 			},
 			SetupMetrics: func(metrics *metricsmocks.Metrics) {
-				metrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChatMessage", "true", mock.AnythingOfType("float64")).Once()
+				metrics.On("ObserveMSGraphClientMethodDuration", "Client.GetChatMessage", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 		},
 		{
@@ -2478,7 +2478,7 @@ func TestUpdateChat(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveMessage", metrics.ActionUpdated, metrics.ActionSourceMattermost, true).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateChatMessage", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateChatMessage", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			UpdateRequired: true,
 		},
@@ -2503,7 +2503,7 @@ func TestUpdateChat(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveMessage", metrics.ActionUpdated, metrics.ActionSourceMattermost, true).Times(1)
-				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateChatMessage", "true", mock.AnythingOfType("float64")).Once()
+				mockmetrics.On("ObserveMSGraphClientMethodDuration", "Client.UpdateChatMessage", "true", "2XX", mock.AnythingOfType("float64")).Once()
 			},
 			UpdateRequired: true,
 		},

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -88,7 +88,7 @@ type Metrics interface {
 	IncrementChangeEventQueueLength(changeType string)
 	DecrementChangeEventQueueLength(changeType string)
 
-	ObserveMSGraphClientMethodDuration(method, success string, elapsed float64)
+	ObserveMSGraphClientMethodDuration(method, success, statusCode string, elapsed float64)
 	ObserveStoreMethodDuration(method, success string, elapsed float64)
 
 	GetRegistry() *prometheus.Registry
@@ -411,7 +411,7 @@ func NewMetrics(info InstanceInfo) Metrics {
 			Help:        "Time to execute the client methods",
 			ConstLabels: additionalLabels,
 		},
-		[]string{"method", "success"},
+		[]string{"method", "success", "status_code"},
 	)
 	m.registry.MustRegister(m.msGraphClientTime)
 
@@ -589,9 +589,9 @@ func (m *metrics) DecrementChangeEventQueueLength(changeType string) {
 	}
 }
 
-func (m *metrics) ObserveMSGraphClientMethodDuration(method, success string, elapsed float64) {
+func (m *metrics) ObserveMSGraphClientMethodDuration(method, success, statusCode string, elapsed float64) {
 	if m != nil {
-		m.msGraphClientTime.With(prometheus.Labels{"method": method, "success": success}).Observe(elapsed)
+		m.msGraphClientTime.With(prometheus.Labels{"method": method, "success": success, "status_code": statusCode}).Observe(elapsed)
 	}
 }
 

--- a/server/metrics/mocks/Metrics.go
+++ b/server/metrics/mocks/Metrics.go
@@ -115,9 +115,9 @@ func (_m *Metrics) ObserveLinkedChannels(count int64) {
 	_m.Called(count)
 }
 
-// ObserveMSGraphClientMethodDuration provides a mock function with given fields: method, success, elapsed
-func (_m *Metrics) ObserveMSGraphClientMethodDuration(method string, success string, elapsed float64) {
-	_m.Called(method, success, elapsed)
+// ObserveMSGraphClientMethodDuration provides a mock function with given fields: method, success, statusCode, elapsed
+func (_m *Metrics) ObserveMSGraphClientMethodDuration(method string, success string, statusCode string, elapsed float64) {
+	_m.Called(method, success, statusCode, elapsed)
 }
 
 // ObserveMessage provides a mock function with given fields: action, source, isDirectMessage

--- a/server/msteams/client_timerlayer/timerlayer.go
+++ b/server/msteams/client_timerlayer/timerlayer.go
@@ -7,7 +7,9 @@
 package client_timerlayer
 
 import (
+	"errors"
 	"io"
+	"strconv"
 	"time"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -24,632 +26,983 @@ type ClientTimerLayer struct {
 }
 
 func (c *ClientTimerLayer) Connect() error {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	err := c.Client.Connect()
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.Connect", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.Connect", success, statusCode, elapsed)
 	return err
 }
 
 func (c *ClientTimerLayer) CreateOrGetChatForUsers(usersIDs []string) (*clientmodels.Chat, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.CreateOrGetChatForUsers(usersIDs)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.CreateOrGetChatForUsers", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.CreateOrGetChatForUsers", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) DeleteChatMessage(userID string, chatID string, msgID string) error {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	err := c.Client.DeleteChatMessage(userID, chatID, msgID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.DeleteChatMessage", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.DeleteChatMessage", success, statusCode, elapsed)
 	return err
 }
 
 func (c *ClientTimerLayer) DeleteMessage(teamID string, channelID string, parentID string, msgID string) error {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	err := c.Client.DeleteMessage(teamID, channelID, parentID, msgID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.DeleteMessage", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.DeleteMessage", success, statusCode, elapsed)
 	return err
 }
 
 func (c *ClientTimerLayer) DeleteSubscription(subscriptionID string) error {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	err := c.Client.DeleteSubscription(subscriptionID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.DeleteSubscription", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.DeleteSubscription", success, statusCode, elapsed)
 	return err
 }
 
 func (c *ClientTimerLayer) GetAppCredentials(applicationID string) ([]clientmodels.Credential, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetAppCredentials(applicationID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetAppCredentials", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetAppCredentials", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetChannelInTeam(teamID string, channelID string) (*clientmodels.Channel, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetChannelInTeam(teamID, channelID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChannelInTeam", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChannelInTeam", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetChannelsInTeam(teamID string, filterQuery string) ([]*clientmodels.Channel, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetChannelsInTeam(teamID, filterQuery)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChannelsInTeam", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChannelsInTeam", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetChat(chatID string) (*clientmodels.Chat, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetChat(chatID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChat", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChat", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetChatMessage(chatID string, messageID string) (*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetChatMessage(chatID, messageID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChatMessage", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChatMessage", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetCodeSnippet(url string) (string, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetCodeSnippet(url)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetCodeSnippet", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetCodeSnippet", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetFileContent(downloadURL string) ([]byte, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetFileContent(downloadURL)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetFileContent", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetFileContent", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetFileContentStream(downloadURL string, writer *io.PipeWriter, bufferSize int64) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	c.Client.GetFileContentStream(downloadURL, writer, bufferSize)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if true {
-		success = "true"
-	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetFileContentStream", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetFileContentStream", success, statusCode, elapsed)
 
 }
 
 func (c *ClientTimerLayer) GetFileSizeAndDownloadURL(weburl string) (int64, string, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, resultVar1, err := c.Client.GetFileSizeAndDownloadURL(weburl)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetFileSizeAndDownloadURL", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetFileSizeAndDownloadURL", success, statusCode, elapsed)
 	return result, resultVar1, err
 }
 
 func (c *ClientTimerLayer) GetHostedFileContent(activityIDs *clientmodels.ActivityIds) ([]byte, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetHostedFileContent(activityIDs)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetHostedFileContent", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetHostedFileContent", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetMe() (*clientmodels.User, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetMe()
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetMe", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetMe", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetMessage(teamID string, channelID string, messageID string) (*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetMessage(teamID, channelID, messageID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetMessage", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetMessage", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetMyID() (string, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetMyID()
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetMyID", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetMyID", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetReply(teamID string, channelID string, messageID string, replyID string) (*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetReply(teamID, channelID, messageID, replyID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetReply", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetReply", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetTeam(teamID string) (*clientmodels.Team, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetTeam(teamID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetTeam", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetTeam", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetTeams(filterQuery string) ([]*clientmodels.Team, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetTeams(filterQuery)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetTeams", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetTeams", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetUser(userID string) (*clientmodels.User, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetUser(userID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetUser", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetUser", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) GetUserAvatar(userID string) ([]byte, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.GetUserAvatar(userID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetUserAvatar", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetUserAvatar", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) ListChannelMessages(teamID string, channelID string, since time.Time) ([]*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.ListChannelMessages(teamID, channelID, since)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListChannelMessages", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListChannelMessages", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) ListChannels(teamID string) ([]clientmodels.Channel, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.ListChannels(teamID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListChannels", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListChannels", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) ListChatMessages(chatID string, since time.Time) ([]*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.ListChatMessages(chatID, since)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListChatMessages", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListChatMessages", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) ListSubscriptions() ([]*clientmodels.Subscription, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.ListSubscriptions()
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListSubscriptions", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListSubscriptions", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) ListTeams() ([]clientmodels.Team, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.ListTeams()
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListTeams", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListTeams", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) ListUsers() ([]clientmodels.User, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.ListUsers()
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListUsers", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListUsers", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) RefreshSubscription(subscriptionID string) (*time.Time, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.RefreshSubscription(subscriptionID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.RefreshSubscription", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.RefreshSubscription", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) RefreshToken(token *oauth2.Token) (*oauth2.Token, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.RefreshToken(token)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.RefreshToken", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.RefreshToken", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) SendChat(chatID string, message string, parentMessage *clientmodels.Message, attachments []*clientmodels.Attachment, mentions []models.ChatMessageMentionable) (*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.SendChat(chatID, message, parentMessage, attachments, mentions)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.SendChat", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SendChat", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) SendMessage(teamID string, channelID string, parentID string, message string) (*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.SendMessage(teamID, channelID, parentID, message)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.SendMessage", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SendMessage", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) SendMessageWithAttachments(teamID string, channelID string, parentID string, message string, attachments []*clientmodels.Attachment, mentions []models.ChatMessageMentionable) (*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.SendMessageWithAttachments(teamID, channelID, parentID, message, attachments, mentions)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.SendMessageWithAttachments", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SendMessageWithAttachments", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) SetChatReaction(chatID string, messageID string, userID string, emoji string) (*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.SetChatReaction(chatID, messageID, userID, emoji)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.SetChatReaction", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SetChatReaction", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) SetReaction(teamID string, channelID string, parentID string, messageID string, userID string, emoji string) (*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.SetReaction(teamID, channelID, parentID, messageID, userID, emoji)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.SetReaction", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SetReaction", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) SubscribeToChannel(teamID string, channelID string, baseURL string, webhookSecret string, certificate string) (*clientmodels.Subscription, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.SubscribeToChannel(teamID, channelID, baseURL, webhookSecret, certificate)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToChannel", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToChannel", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) SubscribeToChannels(baseURL string, webhookSecret string, pay bool, certificate string) (*clientmodels.Subscription, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.SubscribeToChannels(baseURL, webhookSecret, pay, certificate)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToChannels", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToChannels", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) SubscribeToChats(baseURL string, webhookSecret string, pay bool, certificate string) (*clientmodels.Subscription, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.SubscribeToChats(baseURL, webhookSecret, pay, certificate)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToChats", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToChats", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) SubscribeToUserChats(user string, baseURL string, webhookSecret string, pay bool, certificate string) (*clientmodels.Subscription, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.SubscribeToUserChats(user, baseURL, webhookSecret, pay, certificate)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToUserChats", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToUserChats", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) UnsetChatReaction(chatID string, messageID string, userID string, emoji string) (*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.UnsetChatReaction(chatID, messageID, userID, emoji)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.UnsetChatReaction", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.UnsetChatReaction", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) UnsetReaction(teamID string, channelID string, parentID string, messageID string, userID string, emoji string) (*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.UnsetReaction(teamID, channelID, parentID, messageID, userID, emoji)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.UnsetReaction", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.UnsetReaction", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) UpdateChatMessage(chatID string, msgID string, message string, mentions []models.ChatMessageMentionable) (*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.UpdateChatMessage(chatID, msgID, message, mentions)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.UpdateChatMessage", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.UpdateChatMessage", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) UpdateMessage(teamID string, channelID string, parentID string, msgID string, message string, mentions []models.ChatMessageMentionable) (*clientmodels.Message, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.UpdateMessage(teamID, channelID, parentID, msgID, message, mentions)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.UpdateMessage", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.UpdateMessage", success, statusCode, elapsed)
 	return result, err
 }
 
 func (c *ClientTimerLayer) UploadFile(teamID string, channelID string, filename string, filesize int, mimeType string, data io.Reader, chat *clientmodels.Chat) (*clientmodels.Attachment, error) {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
 
 	result, err := c.Client.UploadFile(teamID, channelID, filename, filesize, mimeType, data, chat)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
 	}
-	c.metrics.ObserveMSGraphClientMethodDuration("Client.UploadFile", success, elapsed)
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.UploadFile", success, statusCode, elapsed)
 	return result, err
 }
 

--- a/server/msteams/layer_generators/main.go
+++ b/server/msteams/layer_generators/main.go
@@ -189,14 +189,6 @@ func generateLayer(name, templateFile string) ([]byte, error) {
 			}
 			return strings.Join(vars, ", ")
 		},
-		"errorToBoolean": func(results []string) string {
-			for _, typeName := range results {
-				if isError(typeName) {
-					return "err == nil"
-				}
-			}
-			return "true"
-		},
 		"errorPresent": func(results []string) bool {
 			for _, typeName := range results {
 				if isError(typeName) {

--- a/server/msteams/layer_generators/timer_layer.go.tmpl
+++ b/server/msteams/layer_generators/timer_layer.go.tmpl
@@ -7,7 +7,9 @@
 package client_timerlayer
 
 import (
+	"errors"
 	"io"
+	"strconv"
 	"time"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -25,18 +27,29 @@ type {{.Name}} struct {
 
 {{range $index, $element := .Methods}}
 func (c *{{$.Name}}) {{$index}}({{$element.Params | joinParamsWithType}}) {{$element.Results | joinResultsForSignature}} {
+	statusCode := "2XX"
+	success := "true"
 	start := time.Now()
+
 	{{if $element.Results | len | eq 0}}
 	c.Client.{{$index}}({{$element.Params | joinParams}})
 	{{else}}
 	{{genResultsVars $element.Results false }} := c.Client.{{$index}}({{$element.Params | joinParams}})
 	{{end}}
 	elapsed := float64(time.Since(start)) / float64(time.Second)
-        success := "false"
-        if {{$element.Results | errorToBoolean}} {
-                success = "true"
-        }
-        c.metrics.ObserveMSGraphClientMethodDuration("Client.{{$index}}", success, elapsed)
+
+	{{if $element.Results | errorPresent}}
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
+	}
+	{{end}}
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.{{$index}}", success, statusCode, elapsed)
 	{{ with (genResultsVars $element.Results false ) -}}
 	return {{ . }}
 	{{- end }}


### PR DESCRIPTION
#### Summary
Status code will be set at 2XX for all successful requests as we don't have a returning code coming from the SDK in those cases. For errors, the status code will come from the SDK error and will be set to zero if not present.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56678
