### PR TITLE
MM-57906 Update platform preference when disconnecting

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -568,6 +568,8 @@ func (a *API) oauthRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		Id:        stateArr[2],
 		Message:   userConnectedMessage,
 		ChannelId: stateArr[3],
+		UserId:    a.p.GetBotUserID(),
+		CreateAt:  model.GetMillis(),
 	}
 	_ = a.p.GetAPI().UpdateEphemeralPost(mmUser.Id, post)
 	connectURL := a.p.GetURL() + "/primary-platform"

--- a/server/api.go
+++ b/server/api.go
@@ -568,8 +568,6 @@ func (a *API) oauthRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		Id:        stateArr[2],
 		Message:   userConnectedMessage,
 		ChannelId: stateArr[3],
-		UserId:    a.p.GetBotUserID(),
-		CreateAt:  model.GetMillis(),
 	}
 	_ = a.p.GetAPI().UpdateEphemeralPost(mmUser.Id, post)
 	connectURL := a.p.GetURL() + "/primary-platform"

--- a/server/command.go
+++ b/server/command.go
@@ -527,6 +527,10 @@ func (p *Plugin) executeDisconnectCommand(args *model.CommandArgs) (*model.Comma
 	if err != nil {
 		return p.cmdSuccess(args, fmt.Sprintf("Error: unable to disconnect your account, %s", err.Error()))
 	}
+	err = p.setPrimaryPlatform(args.UserId, PreferenceValuePlatformMM)
+	if err != nil {
+		return p.cmdSuccess(args, fmt.Sprintf("Error: unable to reset your primary platform, %s", err.Error()))
+	}
 
 	_, _ = p.updateAutomutingOnUserDisconnect(args.UserId)
 

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -446,11 +446,16 @@ func TestExecuteDisconnectCommand(t *testing.T) {
 
 		err := th.p.store.SetUserInfo(user1.Id, "team_user_id", &oauth2.Token{AccessToken: "token", Expiry: time.Now().Add(10 * time.Minute)})
 		require.NoError(t, err)
+		err = th.p.setPrimaryPlatform(user1.Id, PreferenceValuePlatformMSTeams)
+		require.NoError(t, err)
 
 		commandResponse, appErr := th.p.executeDisconnectCommand(args)
 		require.Nil(t, appErr)
 		assertNoCommandResponse(t, commandResponse)
 		assertEphemeralResponse(th, t, args, "Your account has been disconnected.")
+
+		require.Equal(t, PreferenceValuePlatformMM, th.p.getPrimaryPlatform(user1.Id))
+
 	})
 }
 

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -455,7 +455,6 @@ func TestExecuteDisconnectCommand(t *testing.T) {
 		assertEphemeralResponse(th, t, args, "Your account has been disconnected.")
 
 		require.Equal(t, PreferenceValuePlatformMM, th.p.getPrimaryPlatform(user1.Id))
-
 	})
 }
 


### PR DESCRIPTION

#### Summary
When a user disconnects from MS Teams, set the primary platform to 'matttermost'. Otherwise when messaged from another connected MM primary user, messages continue to sync.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-57906

