### PR TITLE
MM-57902 Date doesn't get set on updated ephemeral post 

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -568,6 +568,8 @@ func (a *API) oauthRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		Id:        stateArr[2],
 		Message:   userConnectedMessage,
 		ChannelId: stateArr[3],
+		UserId:    a.p.GetBotUserID(),
+		CreateAt:  model.GetMillis(),
 	}
 	_ = a.p.GetAPI().UpdateEphemeralPost(mmUser.Id, post)
 	connectURL := a.p.GetURL() + "/primary-platform"


### PR DESCRIPTION
#### Summary
When updating an ephemeral post, the date and user were not being set. Set the user to bot and the date to now.

#### Ticket Link
 fixes https://mattermost.atlassian.net/browse/MM-57902
