### PR TITLE
Send invite message as bot message, not ephemeral

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -573,9 +573,11 @@ func (a *API) oauthRedirectHandler(w http.ResponseWriter, r *http.Request) {
 	_, appErr = a.p.GetAPI().GetPost(stateArr[2])
 	if appErr == nil {
 		_, appErr = a.p.GetAPI().UpdatePost(post)
+		if appErr != nil {
+			a.p.API.LogWarn("Unable to update post", "post", post.Id, "error", err.Error())
+		}
 	} else {
 		_ = a.p.GetAPI().UpdateEphemeralPost(mmUser.Id, post)
-
 	}
 
 	connectURL := a.p.GetURL() + "/primary-platform"

--- a/server/api.go
+++ b/server/api.go
@@ -569,7 +569,15 @@ func (a *API) oauthRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		Message:   userConnectedMessage,
 		ChannelId: stateArr[3],
 	}
-	_ = a.p.GetAPI().UpdateEphemeralPost(mmUser.Id, post)
+
+	_, appErr = a.p.GetAPI().GetPost(stateArr[2])
+	if appErr == nil {
+		_, appErr = a.p.GetAPI().UpdatePost(post)
+	} else {
+		_ = a.p.GetAPI().UpdateEphemeralPost(mmUser.Id, post)
+
+	}
+
 	connectURL := a.p.GetURL() + "/primary-platform"
 	http.Redirect(w, r, connectURL, http.StatusSeeOther)
 }

--- a/server/connect.go
+++ b/server/connect.go
@@ -101,8 +101,14 @@ func (p *Plugin) SendInviteMessage(user *model.User, pendingSince time.Time, cur
 
 	postID := model.NewId()
 	connectURL := fmt.Sprintf(p.GetURL()+"/connect?post_id=%s&channel_id=%s", postID, channel.Id)
-	connectMessage := message + " " + fmt.Sprintf("[Click here to connect your account](%s)", connectURL)
-	if err := p.botSendDirectMessage(user.Id, connectMessage); err != nil {
+	connectMessage := fmt.Sprintf("%s [Click here to connect your account](%s)", message, connectURL)
+	invitePost := &model.Post{
+		Id:        postID,
+		Message:   connectMessage,
+		UserId:    p.userID,
+		ChannelId: channel.Id,
+	}
+	if err := p.apiClient.Post.CreatePost(invitePost); err != nil {
 		return errors.Wrapf(err, "error sending bot message")
 	}
 

--- a/server/connect.go
+++ b/server/connect.go
@@ -102,7 +102,9 @@ func (p *Plugin) SendInviteMessage(user *model.User, pendingSince time.Time, cur
 	postID := model.NewId()
 	connectURL := fmt.Sprintf(p.GetURL()+"/connect?post_id=%s&channel_id=%s", postID, channel.Id)
 	connectMessage := message + " " + fmt.Sprintf("[Click here to connect your account](%s)", connectURL)
-	p.botSendDirectMessage(user.Id, connectMessage)
+	if err := p.botSendDirectMessage(user.Id, connectMessage); err != nil {
+		return errors.Wrapf(err, "error sending bot message")
+	}
 
 	if err := p.store.StoreInvitedUser(invitedUser); err != nil {
 		return errors.Wrapf(err, "error storing user in invite list")

--- a/server/connect.go
+++ b/server/connect.go
@@ -97,18 +97,20 @@ func (p *Plugin) SendInviteMessage(user *model.User, pendingSince time.Time, cur
 	if err != nil {
 		return errors.Wrapf(err, "failed to get bot DM channel with user_id %s", user.Id)
 	}
-	message := fmt.Sprintf("@%s, you're invited to use the MS Teams connected experience. ", user.Username)
 
-	postID := model.NewId()
-	connectURL := fmt.Sprintf(p.GetURL()+"/connect?post_id=%s&channel_id=%s", postID, channel.Id)
-	connectMessage := fmt.Sprintf("%s [Click here to connect your account](%s)", message, connectURL)
+	message := fmt.Sprintf("@%s, you're invited to use the MS Teams connected experience. ", user.Username)
 	invitePost := &model.Post{
-		Id:        postID,
-		Message:   connectMessage,
+		Message:   message,
 		UserId:    p.userID,
 		ChannelId: channel.Id,
 	}
 	if err := p.apiClient.Post.CreatePost(invitePost); err != nil {
+		return errors.Wrapf(err, "error sending bot message")
+	}
+
+	connectURL := fmt.Sprintf(p.GetURL()+"/connect?post_id=%s&channel_id=%s", invitePost.Id, channel.Id)
+	invitePost.Message = fmt.Sprintf("%s [Click here to connect your account](%s)", invitePost.Message, connectURL)
+	if err := p.apiClient.Post.UpdatePost(invitePost); err != nil {
 		return errors.Wrapf(err, "error sending bot message")
 	}
 


### PR DESCRIPTION

#### Summary
Invite messages need to be send from bot, but not as ephemeral messages.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

