### PR TITLE
Send invite message as bot message, not ephemeral (#607)

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -569,7 +569,17 @@ func (a *API) oauthRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		Message:   userConnectedMessage,
 		ChannelId: stateArr[3],
 	}
-	_ = a.p.GetAPI().UpdateEphemeralPost(mmUser.Id, post)
+
+	_, appErr = a.p.GetAPI().GetPost(stateArr[2])
+	if appErr == nil {
+		_, appErr = a.p.GetAPI().UpdatePost(post)
+		if appErr != nil {
+			a.p.API.LogWarn("Unable to update post", "post", post.Id, "error", err.Error())
+		}
+	} else {
+		_ = a.p.GetAPI().UpdateEphemeralPost(mmUser.Id, post)
+	}
+
 	connectURL := a.p.GetURL() + "/primary-platform"
 	http.Redirect(w, r, connectURL, http.StatusSeeOther)
 }


### PR DESCRIPTION
* send invite message as bot message, not ephemeral

* update connect message

* check error

* cleanup

* edit post message to not set id

(cherry picked from commit 9c70367b8e1b8bc62b0ae3dedd92a92cda2262bb)

