### PR TITLE
[MM-57821] Reduce number of calls to GetUser in syncUsers

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -718,20 +718,23 @@ func (p *Plugin) syncUsers() {
 					continue
 				}
 
-				user, err := p.API.GetUser(mmUser.Id)
-				if err != nil {
-					p.API.LogWarn("Unable to fetch MM user", "user_id", mmUser.Id, "teams_user_id", msUser.ID, "error", err.Error())
-					continue
-				}
+				if configuration.AutomaticallyPromoteSyntheticUsers {
+					// We need to retrieve the user individually because `GetUsers` does not return AuthData
+					user, err := p.API.GetUser(mmUser.Id)
+					if err != nil {
+						p.API.LogWarn("Unable to fetch MM user", "user_id", mmUser.Id, "teams_user_id", msUser.ID, "error", err.Error())
+						continue
+					}
 
-				// Update AuthService/AuthData if it changed
-				if configuration.AutomaticallyPromoteSyntheticUsers && (mmUser.AuthService != configuration.SyntheticUserAuthService || (user.AuthData != nil && authData != "" && *user.AuthData != authData)) {
-					p.API.LogInfo("Updating user auth service", "user_id", mmUser.Id, "teams_user_id", msUser.ID, "auth_service", configuration.SyntheticUserAuthService)
-					if _, err := p.API.UpdateUserAuth(mmUser.Id, &model.UserAuth{
-						AuthService: configuration.SyntheticUserAuthService,
-						AuthData:    &authData,
-					}); err != nil {
-						p.API.LogWarn("Unable to update user auth service during sync user job", "user_id", mmUser.Id, "teams_user_id", msUser.ID, "error", err.Error())
+					// Update AuthService/AuthData if it changed
+					if mmUser.AuthService != configuration.SyntheticUserAuthService || (user.AuthData != nil && authData != "" && *user.AuthData != authData) {
+						p.API.LogInfo("Updating user auth service", "user_id", mmUser.Id, "teams_user_id", msUser.ID, "auth_service", configuration.SyntheticUserAuthService)
+						if _, err := p.API.UpdateUserAuth(mmUser.Id, &model.UserAuth{
+							AuthService: configuration.SyntheticUserAuthService,
+							AuthData:    &authData,
+						}); err != nil {
+							p.API.LogWarn("Unable to update user auth service during sync user job", "user_id", mmUser.Id, "teams_user_id", msUser.ID, "error", err.Error())
+						}
 					}
 				}
 


### PR DESCRIPTION
#### Summary
We are calling GetUser for each synthetic during the syncUsers job, but we only need to make this call if autopromote is `on`.

Reminder: the reason why we need this call is because `GetUsers` does not return `AuthData`: it's sanitized, so we make `GetUser` to get this info. Ideally, plugins should have access to more unsanitized data, but it involves a much heavier change on mattermost server, getting security validation etc... the change is probably not worth investing time in right now.

I don't expect this PR to have a significant positive perf impact as Jesus believes that `GetUser` is pulling data from cache rather than DB, but it's probably still better to only do the call when needed rather than all the time.

#### QA
I think for QA, just making sure that the syncUsers job will works as before is the best way to go

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57821

