### PR TITLE
Hide connect message, hide attachment message on update

### DIFF
--- a/server/bot_messages.go
+++ b/server/bot_messages.go
@@ -21,8 +21,10 @@ func (p *Plugin) botSendDirectMessage(userID, message string) error {
 }
 
 func (p *Plugin) handlePromptForConnection(userID, channelID string) {
-	message := "Some users in this conversation rely on Microsoft Teams to receive your messages, but your account isn't connected. "
-	p.SendConnectMessage(channelID, userID, message)
+	// For now, don't display the connect message
+
+	// message := "Some users in this conversation rely on Microsoft Teams to receive your messages, but your account isn't connected. "
+	// p.SendConnectMessage(channelID, userID, message)
 }
 
 func (p *Plugin) SendConnectMessage(channelID string, userID string, message string) {

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -470,21 +470,22 @@ func (ah *ActivityHandler) handleUpdatedActivity(msg *clientmodels.Message, subs
 		return metrics.DiscardedReasonInactiveUser
 	}
 
-	post, skippedFileAttachments, _ := ah.msgToPost(channelID, senderID, msg, chat, true)
+	post, _, _ := ah.msgToPost(channelID, senderID, msg, chat, true)
 	post.Id = postInfo.MattermostID
 
-	if skippedFileAttachments {
-		_, appErr := ah.plugin.GetAPI().CreatePost(&model.Post{
-			ChannelId: post.ChannelId,
-			UserId:    ah.plugin.GetBotUserID(),
-			Message:   "Attachments added to an existing post in Microsoft Teams aren't delivered to Mattermost.",
-			// Anchor the post immediately after (never before) the post that was edited.
-			CreateAt: post.CreateAt + 1,
-		})
-		if appErr != nil {
-			ah.plugin.GetAPI().LogWarn("Failed to notify channel of skipped attachment", "channel_id", post.ChannelId, "post_id", post.Id, "error", appErr)
-		}
-	}
+	// For now, don't display this message on update
+	// if skippedFileAttachments {
+	// _, appErr := ah.plugin.GetAPI().CreatePost(&model.Post{
+	// 	ChannelId: post.ChannelId,
+	// 	UserId:    ah.plugin.GetBotUserID(),
+	// 	Message:   "Attachments added to an existing post in Microsoft Teams aren't delivered to Mattermost.",
+	// 	// Anchor the post immediately after (never before) the post that was edited.
+	// 	CreateAt: post.CreateAt + 1,
+	// })
+	// if appErr != nil {
+	// 	ah.plugin.GetAPI().LogWarn("Failed to notify channel of skipped attachment", "channel_id", post.ChannelId, "post_id", post.Id, "error", appErr)
+	// }
+	// }
 
 	ah.IgnorePluginHooksMap.Store(fmt.Sprintf("post_%s", post.Id), true)
 	if _, appErr := ah.plugin.GetAPI().UpdatePost(post); appErr != nil {


### PR DESCRIPTION
#### Summary

- Hide messages that ask a user to "Click here to connect".
- The message will still display if a connected user loses their connection `OnDisconnectedTokenHandler` and if the command `/msteams connect` is run. 

- The warning message regarding messages not being delivered will not be displayed.

Code was only commented out, as we expect to re-enable in the future.

#### Ticket Link

 Fixes https://mattermost.atlassian.net/browse/MM-57920

