### PR TITLE
only display message if user is connected

### DIFF
--- a/server/automute_preferences.go
+++ b/server/automute_preferences.go
@@ -35,7 +35,16 @@ func (p *Plugin) updateAutomutingOnPreferencesChanged(_ *plugin.Context, prefere
 	}
 
 	for _, userID := range userIDsToDisable {
-		p.notifyUserMattermostPrimary(userID)
+		if connected, err := p.isUserConnected(userID); err != nil {
+			p.API.LogWarn(
+				"Unable to determine if user connected",
+				"user_id", userID,
+				"error", err.Error(),
+			)
+		} else if connected {
+			// Don't notify if disconnected
+			p.notifyUserMattermostPrimary(userID)
+		}
 
 		_, err := p.disableAutomute(userID)
 		if err != nil {


### PR DESCRIPTION

#### Summary
When the user changes their "primary" platform, we display a bot message. We also implemented a fix that resets the users primary platform back to Mattermost upon disconnect. This resulted in the bot message whenever `/msteams disconnect` was run.

This PRs as a check for the user being active and only showing the message if the user is active.


#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-57975

