### PR TITLE
[MM-57533] Send a warning when selective sync blocks a message

### DIFF
--- a/server/automute_preferences_test.go
+++ b/server/automute_preferences_test.go
@@ -129,8 +129,8 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 			{
 				UserId:   user.Id,
 				Category: PreferenceCategoryPlugin,
-				Name:     PreferenceNamePlatform,
-				Value:    PreferenceValuePlatformMSTeams,
+				Name:     storemodels.PreferenceNamePlatform,
+				Value:    storemodels.PreferenceValuePlatformMSTeams,
 			},
 		})
 

--- a/server/bot_messages.go
+++ b/server/bot_messages.go
@@ -72,7 +72,7 @@ func (p *Plugin) notifyUserTeamsPrimary(userID string) {
 	}
 }
 
-const messageWontSyncToMSTeams = "All the users in this conversation are using MSTeams as their primary platform, this message will not be sent to MSTeams."
+const messageWontSyncToMSTeams = "As all the users in this conversation are using Teams as their primary platform, this message will not be sent to Teams."
 
 func (p *Plugin) notifyMessageWontSync(userID, channelID string) {
 	post := &model.Post{

--- a/server/bot_messages.go
+++ b/server/bot_messages.go
@@ -71,3 +71,15 @@ func (p *Plugin) notifyUserTeamsPrimary(userID string) {
 		p.GetAPI().LogWarn("Failed to notify user is Teams primary", "user_id", userID, "error", err)
 	}
 }
+
+const messageWontSyncToMSTeams = "All the users in this conversation are using MSTeams as their primary platform, this message will not be sent to MSTeams."
+
+func (p *Plugin) notifyMessageWontSync(userID, channelID string) {
+	post := &model.Post{
+		Id:        model.NewId(),
+		ChannelId: channelID,
+		UserId:    p.GetBotUserID(),
+		Message:   messageWontSyncToMSTeams,
+	}
+	p.API.SendEphemeralPost(userID, post)
+}

--- a/server/helper_test.go
+++ b/server/helper_test.go
@@ -140,14 +140,12 @@ func (th *testHelper) clearDatabase(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func (th *testHelper) reset(t *testing.T, keepDB bool) *testHelper {
+func (th *testHelper) Reset(t *testing.T) *testHelper {
 	t.Helper()
 
-	if !keepDB {
-		// Wipe the tables for this plugin to ensure a clean slate. Note that we don't currently
-		// touch any Mattermost tables.
-		th.clearDatabase(t)
-	}
+	// Wipe the tables for this plugin to ensure a clean slate. Note that we don't currently
+	// touch any Mattermost tables.
+	th.clearDatabase(t)
 
 	appClientMock := &mocks.Client{}
 	clientMock := &mocks.Client{}
@@ -200,16 +198,6 @@ func (th *testHelper) reset(t *testing.T, keepDB bool) *testHelper {
 	})
 
 	return th
-}
-
-func (th *testHelper) Reset(t *testing.T) *testHelper {
-	t.Helper()
-	return th.reset(t, false)
-}
-
-func (th *testHelper) ResetPreserveDB(t *testing.T) *testHelper {
-	t.Helper()
-	return th.reset(t, true)
 }
 
 func (th *testHelper) SetupTeam(t *testing.T) *model.Team {
@@ -461,7 +449,7 @@ func (th *testHelper) assertEphemeralMessage(t *testing.T, userID, channelID, me
 	}
 }
 
-func (th *testHelper) assertNoEphemeralMessage(t *testing.T, userID, channelID, message string, maxWaitTime time.Duration) {
+func (th *testHelper) assertNoEphemeralMessageWithContent(t *testing.T, userID, channelID, message string, maxWaitTime time.Duration) {
 	t.Helper()
 
 	websocketClient := th.GetWebsocketClientForUser(t, userID)

--- a/server/helper_test.go
+++ b/server/helper_test.go
@@ -500,7 +500,6 @@ func (th *testHelper) assertNoEphemeralMessage(t *testing.T, userID, channelID, 
 			return
 		}
 	}
-	return
 }
 
 func (th *testHelper) retrieveEphemeralPost(t *testing.T, userID, channelID string) *model.Post {

--- a/server/helper_test.go
+++ b/server/helper_test.go
@@ -210,7 +210,6 @@ func (th *testHelper) Reset(t *testing.T) *testHelper {
 func (th *testHelper) ResetPreserveDB(t *testing.T) *testHelper {
 	t.Helper()
 	return th.reset(t, true)
-
 }
 
 func (th *testHelper) SetupTeam(t *testing.T) *model.Team {

--- a/server/helper_test.go
+++ b/server/helper_test.go
@@ -321,10 +321,30 @@ func (th *testHelper) SetupRemoteUser(t *testing.T, team *model.Team) *model.Use
 	return user
 }
 
+func (th *testHelper) SetupSyntheticUser(t *testing.T, team *model.Team) *model.User {
+	t.Helper()
+
+	user := th.SetupRemoteUser(t, team)
+	teamsID := "t" + user.Id
+	err := th.p.store.SetUserInfo(user.Id, teamsID, nil)
+	require.NoError(t, err)
+
+	return user
+}
+
 func (th *testHelper) ConnectUser(t *testing.T, userID string) {
 	teamID := "t" + userID
 	err := th.p.store.SetUserInfo(userID, teamID, &oauth2.Token{AccessToken: "token", Expiry: time.Now().Add(10 * time.Minute)})
 	require.NoError(t, err)
+}
+
+func (th *testHelper) SetupConnectedUser(t *testing.T, team *model.Team) *model.User {
+	t.Helper()
+
+	user := th.SetupUser(t, team)
+	th.ConnectUser(t, user.Id)
+
+	return user
 }
 
 func (th *testHelper) SetupSysadmin(t *testing.T, team *model.Team) *model.User {
@@ -411,7 +431,7 @@ func (th *testHelper) GetWebsocketClientForUser(t *testing.T, userID string) *mo
 	}
 
 	websocketClient := th.websocketClients[userID]
-	require.NotNil(t, websocketClient, "websocket client must be setup first")
+	require.NotNil(t, websocketClient, "websocket client must be setup first by calling SetupWebsocketClientForUser")
 
 	return websocketClient
 }

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -133,7 +133,11 @@ func (p *Plugin) MessageHasBeenPosted(_ *plugin.Context, post *model.Post) {
 			}
 
 			if p.getConfiguration().SelectiveSync && !chatMembersSpanPlatforms {
-				p.notifyMessageWontSync(post.UserId, post.ChannelId)
+				// if selective sync rejects this message and the user main platform is teams,
+				// we notify the user that the message won't be sent to teams
+				if p.isUsersPrimaryPlatformTeams(post.UserId) {
+					p.notifyMessageWontSync(post.UserId, post.ChannelId)
+				}
 				return
 			}
 		}

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -97,6 +97,10 @@ func (p *Plugin) MessageHasBeenPosted(_ *plugin.Context, post *model.Post) {
 		return
 	}
 
+	if post.UserId == p.GetBotUserID() {
+		return
+	}
+
 	isDirectOrGroupMessage := channel.IsGroupOrDirect()
 
 	if post.Props != nil {
@@ -129,6 +133,7 @@ func (p *Plugin) MessageHasBeenPosted(_ *plugin.Context, post *model.Post) {
 			}
 
 			if p.getConfiguration().SelectiveSync && !chatMembersSpanPlatforms {
+				p.notifyMessageWontSync(post.UserId, post.ChannelId)
 				return
 			}
 		}

--- a/server/message_hooks_test.go
+++ b/server/message_hooks_test.go
@@ -2889,7 +2889,6 @@ func TestMessageHasBeenPosted(t *testing.T) {
 	// TODO: remove this when the issue is fixed in the API
 	getDirectChannel := func(t *testing.T, senderID, receiverID string) *model.Channel {
 		t.Helper()
-		// cmnt
 
 		channel, appErr := th.p.API.GetDirectChannel(senderID, receiverID)
 		if appErr != nil {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -956,3 +956,17 @@ func (p *Plugin) OnSharedChannelsSyncMsg(msg *model.SyncMsg, _ *model.RemoteClus
 
 	return resp, nil
 }
+
+func (p *Plugin) areUsersSynthetic(usersID []string) (bool, error) {
+	for _, userID := range usersID {
+		user, err := p.API.GetUser(userID)
+		if err != nil {
+			return false, fmt.Errorf("unable to get user %s: %w", userID, err)
+		}
+		isRemote := p.IsRemoteUser(user)
+		if !isRemote {
+			return false, nil
+		}
+	}
+	return true, nil
+}


### PR DESCRIPTION
#### Summary
Send a warning when selective sync blocks a message + Add tests on the `MessageWIllBePosted` hook.

#### QA Steps
- Make sure Selective Sync is on
- Have 2 MSTeams users connected to Mattermost
- When user 1 tries to message user 2, an ephemeral message let them know that the message won't be sent to MS Teams

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57533