### PR TITLE
(chore) Rename plugin's userID to botUsertID

### DIFF
--- a/server/automute_preferences_test.go
+++ b/server/automute_preferences_test.go
@@ -67,7 +67,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelNotAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, dmChannel.Id, user.Id)
-		th.assertDMFromUser(t, p.botID, user.Id, userChoseMattermostPrimaryMessage)
+		th.assertDMFromUser(t, p.botUsertID, user.Id, userChoseMattermostPrimaryMessage)
 
 		p.PreferencesHaveChanged(&plugin.Context{}, []model.Preference{
 			{
@@ -83,7 +83,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
 		assertChannelAutomuted(t, p, dmChannel.Id, user.Id)
-		th.assertDMFromUser(t, p.botID, user.Id, userChoseTeamsPrimaryMessage)
+		th.assertDMFromUser(t, p.botUsertID, user.Id, userChoseTeamsPrimaryMessage)
 	})
 
 	t.Run("should unmute linked channels when their primary platform changes from MS Teams to MM", func(t *testing.T) {
@@ -103,7 +103,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
 		assertChannelAutomuted(t, p, dmChannel.Id, user.Id)
-		th.assertDMFromUser(t, p.botID, user.Id, userChoseTeamsPrimaryMessage)
+		th.assertDMFromUser(t, p.botUsertID, user.Id, userChoseTeamsPrimaryMessage)
 
 		p.PreferencesHaveChanged(&plugin.Context{}, []model.Preference{
 			{
@@ -119,7 +119,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelNotAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, dmChannel.Id, user.Id)
-		th.assertDMFromUser(t, p.botID, user.Id, userChoseMattermostPrimaryMessage)
+		th.assertDMFromUser(t, p.botUsertID, user.Id, userChoseMattermostPrimaryMessage)
 	})
 
 	t.Run("should unmute linked channels when a MS Teams user disconnects", func(t *testing.T) {
@@ -139,7 +139,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
 		assertChannelAutomuted(t, p, dmChannel.Id, user.Id)
-		th.assertDMFromUser(t, p.botID, user.Id, userChoseTeamsPrimaryMessage)
+		th.assertDMFromUser(t, p.botUsertID, user.Id, userChoseTeamsPrimaryMessage)
 
 		checkTime := model.GetMillisForTime(time.Now())
 		args := &model.CommandArgs{
@@ -151,7 +151,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelNotAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, dmChannel.Id, user.Id)
-		th.assertNoDMFromUser(t, p.botID, user.Id, checkTime)
+		th.assertNoDMFromUser(t, p.botUsertID, user.Id, checkTime)
 	})
 
 	t.Run("should do nothing when unrelated preferences change", func(t *testing.T) {
@@ -165,7 +165,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 				Value:    "full",
 			},
 		})
-		th.assertNoDMFromUser(t, p.botID, user.Id, model.GetMillisForTime(time.Now().Add(-5*time.Second)))
+		th.assertNoDMFromUser(t, p.botUsertID, user.Id, model.GetMillisForTime(time.Now().Add(-5*time.Second)))
 	})
 
 	t.Run("should do nothing when an unconnected user turns on automuting", func(t *testing.T) {
@@ -196,7 +196,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelNotAutomuted(t, p, linkedChannel.Id, unconnectedUser.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, unconnectedUser.Id)
 		assertChannelNotAutomuted(t, p, dmChannel.Id, unconnectedUser.Id)
-		th.assertNoDMFromUser(t, p.botID, unconnectedUser.Id, model.GetMillisForTime(time.Now().Add(-5*time.Second)))
+		th.assertNoDMFromUser(t, p.botUsertID, unconnectedUser.Id, model.GetMillisForTime(time.Now().Add(-5*time.Second)))
 	})
 
 	t.Run("should not affect other users when a connected user turns on automuting", func(t *testing.T) {
@@ -227,7 +227,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		})
 
 		assertUserHasAutomuteEnabled(t, p, user.Id)
-		th.assertDMFromUser(t, p.botID, user.Id, userChoseTeamsPrimaryMessage)
+		th.assertDMFromUser(t, p.botUsertID, user.Id, userChoseTeamsPrimaryMessage)
 
 		assertChannelAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
@@ -270,7 +270,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		})
 
 		assertUserHasAutomuteEnabled(t, p, user.Id)
-		th.assertDMFromUser(t, p.botID, user.Id, userChoseTeamsPrimaryMessage)
+		th.assertDMFromUser(t, p.botUsertID, user.Id, userChoseTeamsPrimaryMessage)
 
 		for _, channel := range channels {
 			assertChannelAutomuted(t, p, channel.Id, user.Id)
@@ -286,7 +286,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		})
 
 		assertUserHasAutomuteDisabled(t, p, user.Id)
-		th.assertDMFromUser(t, p.botID, user.Id, userChoseMattermostPrimaryMessage)
+		th.assertDMFromUser(t, p.botUsertID, user.Id, userChoseMattermostPrimaryMessage)
 
 		for _, channel := range channels {
 			assertChannelNotAutomuted(t, p, channel.Id, user.Id)

--- a/server/automute_preferences_test.go
+++ b/server/automute_preferences_test.go
@@ -67,7 +67,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelNotAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, dmChannel.Id, user.Id)
-		th.assertDMFromUser(t, p.userID, user.Id, userChoseMattermostPrimaryMessage)
+		th.assertDMFromUser(t, p.botID, user.Id, userChoseMattermostPrimaryMessage)
 
 		p.PreferencesHaveChanged(&plugin.Context{}, []model.Preference{
 			{
@@ -83,7 +83,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
 		assertChannelAutomuted(t, p, dmChannel.Id, user.Id)
-		th.assertDMFromUser(t, p.userID, user.Id, userChoseTeamsPrimaryMessage)
+		th.assertDMFromUser(t, p.botID, user.Id, userChoseTeamsPrimaryMessage)
 	})
 
 	t.Run("should unmute linked channels when their primary platform changes from MS Teams to MM", func(t *testing.T) {
@@ -103,7 +103,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
 		assertChannelAutomuted(t, p, dmChannel.Id, user.Id)
-		th.assertDMFromUser(t, p.userID, user.Id, userChoseTeamsPrimaryMessage)
+		th.assertDMFromUser(t, p.botID, user.Id, userChoseTeamsPrimaryMessage)
 
 		p.PreferencesHaveChanged(&plugin.Context{}, []model.Preference{
 			{
@@ -119,7 +119,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelNotAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, dmChannel.Id, user.Id)
-		th.assertDMFromUser(t, p.userID, user.Id, userChoseMattermostPrimaryMessage)
+		th.assertDMFromUser(t, p.botID, user.Id, userChoseMattermostPrimaryMessage)
 	})
 
 	t.Run("should unmute linked channels when a MS Teams user disconnects", func(t *testing.T) {
@@ -139,7 +139,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
 		assertChannelAutomuted(t, p, dmChannel.Id, user.Id)
-		th.assertDMFromUser(t, p.userID, user.Id, userChoseTeamsPrimaryMessage)
+		th.assertDMFromUser(t, p.botID, user.Id, userChoseTeamsPrimaryMessage)
 
 		checkTime := model.GetMillisForTime(time.Now())
 		args := &model.CommandArgs{
@@ -151,7 +151,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelNotAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, dmChannel.Id, user.Id)
-		th.assertNoDMFromUser(t, p.userID, user.Id, checkTime)
+		th.assertNoDMFromUser(t, p.botID, user.Id, checkTime)
 	})
 
 	t.Run("should do nothing when unrelated preferences change", func(t *testing.T) {
@@ -165,7 +165,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 				Value:    "full",
 			},
 		})
-		th.assertNoDMFromUser(t, p.userID, user.Id, model.GetMillisForTime(time.Now().Add(-5*time.Second)))
+		th.assertNoDMFromUser(t, p.botID, user.Id, model.GetMillisForTime(time.Now().Add(-5*time.Second)))
 	})
 
 	t.Run("should do nothing when an unconnected user turns on automuting", func(t *testing.T) {
@@ -196,7 +196,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		assertChannelNotAutomuted(t, p, linkedChannel.Id, unconnectedUser.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, unconnectedUser.Id)
 		assertChannelNotAutomuted(t, p, dmChannel.Id, unconnectedUser.Id)
-		th.assertNoDMFromUser(t, p.userID, unconnectedUser.Id, model.GetMillisForTime(time.Now().Add(-5*time.Second)))
+		th.assertNoDMFromUser(t, p.botID, unconnectedUser.Id, model.GetMillisForTime(time.Now().Add(-5*time.Second)))
 	})
 
 	t.Run("should not affect other users when a connected user turns on automuting", func(t *testing.T) {
@@ -227,7 +227,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		})
 
 		assertUserHasAutomuteEnabled(t, p, user.Id)
-		th.assertDMFromUser(t, p.userID, user.Id, userChoseTeamsPrimaryMessage)
+		th.assertDMFromUser(t, p.botID, user.Id, userChoseTeamsPrimaryMessage)
 
 		assertChannelAutomuted(t, p, linkedChannel.Id, user.Id)
 		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
@@ -270,7 +270,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		})
 
 		assertUserHasAutomuteEnabled(t, p, user.Id)
-		th.assertDMFromUser(t, p.userID, user.Id, userChoseTeamsPrimaryMessage)
+		th.assertDMFromUser(t, p.botID, user.Id, userChoseTeamsPrimaryMessage)
 
 		for _, channel := range channels {
 			assertChannelAutomuted(t, p, channel.Id, user.Id)
@@ -286,7 +286,7 @@ func TestUpdateAutomutingOnPreferencesChanged(t *testing.T) {
 		})
 
 		assertUserHasAutomuteDisabled(t, p, user.Id)
-		th.assertDMFromUser(t, p.userID, user.Id, userChoseMattermostPrimaryMessage)
+		th.assertDMFromUser(t, p.botID, user.Id, userChoseMattermostPrimaryMessage)
 
 		for _, channel := range channels {
 			assertChannelNotAutomuted(t, p, channel.Id, user.Id)

--- a/server/bot_messages.go
+++ b/server/bot_messages.go
@@ -8,14 +8,14 @@ import (
 )
 
 func (p *Plugin) botSendDirectMessage(userID, message string) error {
-	channel, err := p.apiClient.Channel.GetDirect(userID, p.userID)
+	channel, err := p.apiClient.Channel.GetDirect(userID, p.botID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get bot DM channel with user_id %s", userID)
 	}
 
 	return p.apiClient.Post.CreatePost(&model.Post{
 		Message:   message,
-		UserId:    p.userID,
+		UserId:    p.botID,
 		ChannelId: channel.Id,
 	})
 }

--- a/server/bot_messages.go
+++ b/server/bot_messages.go
@@ -8,14 +8,14 @@ import (
 )
 
 func (p *Plugin) botSendDirectMessage(userID, message string) error {
-	channel, err := p.apiClient.Channel.GetDirect(userID, p.botID)
+	channel, err := p.apiClient.Channel.GetDirect(userID, p.botUsertID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get bot DM channel with user_id %s", userID)
 	}
 
 	return p.apiClient.Post.CreatePost(&model.Post{
 		Message:   message,
-		UserId:    p.botID,
+		UserId:    p.botUsertID,
 		ChannelId: channel.Id,
 	})
 }

--- a/server/command.go
+++ b/server/command.go
@@ -50,7 +50,7 @@ func (p *Plugin) cmdError(args *model.CommandArgs, detailedError string) (*model
 func (p *Plugin) sendBotEphemeralPost(userID, channelID, message string) {
 	_ = p.API.SendEphemeralPost(userID, &model.Post{
 		Message:   message,
-		UserId:    p.botID,
+		UserId:    p.botUsertID,
 		ChannelId: channelID,
 	})
 }
@@ -245,7 +245,7 @@ func (p *Plugin) executeLinkCommand(args *model.CommandArgs, parameters []string
 			TeamId:    channelLink.MattermostTeamID,
 			Home:      true,
 			ReadOnly:  false,
-			CreatorId: p.botID,
+			CreatorId: p.botUsertID,
 			RemoteId:  p.remoteID,
 			ShareName: channelLink.MattermostChannelID,
 		}); err != nil {
@@ -492,22 +492,22 @@ func (p *Plugin) executeConnectBotCommand(args *model.CommandArgs) (*model.Comma
 		return p.cmdError(args, "Unable to connect the bot account, only system admins can connect the bot account.")
 	}
 
-	if storedToken, _ := p.store.GetTokenForMattermostUser(p.botID); storedToken != nil {
+	if storedToken, _ := p.store.GetTokenForMattermostUser(p.botUsertID); storedToken != nil {
 		return p.cmdError(args, "The bot account is already connected to MS Teams. Please disconnect the bot account first before connecting again.")
 	}
 
 	genericErrorMessage := "Error in trying to connect the bot account, please try again."
 
-	hasRightToConnect, err := p.UserHasRightToConnect(p.botID)
+	hasRightToConnect, err := p.UserHasRightToConnect(p.botUsertID)
 	if err != nil {
-		p.API.LogWarn("Error in checking if the bot user has the right to connect", "bot_user_id", p.botID, "error", err.Error())
+		p.API.LogWarn("Error in checking if the bot user has the right to connect", "bot_user_id", p.botUsertID, "error", err.Error())
 		return p.cmdError(args, genericErrorMessage)
 	}
 
 	if !hasRightToConnect {
-		canOpenlyConnect, openConnectErr := p.UserCanOpenlyConnect(p.botID)
+		canOpenlyConnect, openConnectErr := p.UserCanOpenlyConnect(p.botUsertID)
 		if openConnectErr != nil {
-			p.API.LogWarn("Error in checking if the bot user can openly connect", "bot_user_id", p.botID, "error", openConnectErr.Error())
+			p.API.LogWarn("Error in checking if the bot user can openly connect", "bot_user_id", p.botUsertID, "error", openConnectErr.Error())
 			return p.cmdError(args, genericErrorMessage)
 		}
 
@@ -549,11 +549,11 @@ func (p *Plugin) executeDisconnectBotCommand(args *model.CommandArgs) (*model.Co
 		return p.cmdError(args, "Unable to disconnect the bot account, only system admins can disconnect the bot account.")
 	}
 
-	if _, err := p.store.MattermostToTeamsUserID(p.botID); err != nil {
+	if _, err := p.store.MattermostToTeamsUserID(p.botUsertID); err != nil {
 		return p.cmdSuccess(args, "Error: unable to find the connected bot account")
 	}
 
-	if err := p.store.DeleteUserInfo(p.botID); err != nil {
+	if err := p.store.DeleteUserInfo(p.botUsertID); err != nil {
 		return p.cmdSuccess(args, fmt.Sprintf("Error: unable to disconnect the bot account, %s", err.Error()))
 	}
 

--- a/server/command.go
+++ b/server/command.go
@@ -50,7 +50,7 @@ func (p *Plugin) cmdError(args *model.CommandArgs, detailedError string) (*model
 func (p *Plugin) sendBotEphemeralPost(userID, channelID, message string) {
 	_ = p.API.SendEphemeralPost(userID, &model.Post{
 		Message:   message,
-		UserId:    p.userID,
+		UserId:    p.botID,
 		ChannelId: channelID,
 	})
 }
@@ -245,7 +245,7 @@ func (p *Plugin) executeLinkCommand(args *model.CommandArgs, parameters []string
 			TeamId:    channelLink.MattermostTeamID,
 			Home:      true,
 			ReadOnly:  false,
-			CreatorId: p.userID,
+			CreatorId: p.botID,
 			RemoteId:  p.remoteID,
 			ShareName: channelLink.MattermostChannelID,
 		}); err != nil {
@@ -492,22 +492,22 @@ func (p *Plugin) executeConnectBotCommand(args *model.CommandArgs) (*model.Comma
 		return p.cmdError(args, "Unable to connect the bot account, only system admins can connect the bot account.")
 	}
 
-	if storedToken, _ := p.store.GetTokenForMattermostUser(p.userID); storedToken != nil {
+	if storedToken, _ := p.store.GetTokenForMattermostUser(p.botID); storedToken != nil {
 		return p.cmdError(args, "The bot account is already connected to MS Teams. Please disconnect the bot account first before connecting again.")
 	}
 
 	genericErrorMessage := "Error in trying to connect the bot account, please try again."
 
-	hasRightToConnect, err := p.UserHasRightToConnect(p.userID)
+	hasRightToConnect, err := p.UserHasRightToConnect(p.botID)
 	if err != nil {
-		p.API.LogWarn("Error in checking if the bot user has the right to connect", "bot_user_id", p.userID, "error", err.Error())
+		p.API.LogWarn("Error in checking if the bot user has the right to connect", "bot_user_id", p.botID, "error", err.Error())
 		return p.cmdError(args, genericErrorMessage)
 	}
 
 	if !hasRightToConnect {
-		canOpenlyConnect, openConnectErr := p.UserCanOpenlyConnect(p.userID)
+		canOpenlyConnect, openConnectErr := p.UserCanOpenlyConnect(p.botID)
 		if openConnectErr != nil {
-			p.API.LogWarn("Error in checking if the bot user can openly connect", "bot_user_id", p.userID, "error", openConnectErr.Error())
+			p.API.LogWarn("Error in checking if the bot user can openly connect", "bot_user_id", p.botID, "error", openConnectErr.Error())
 			return p.cmdError(args, genericErrorMessage)
 		}
 
@@ -549,11 +549,11 @@ func (p *Plugin) executeDisconnectBotCommand(args *model.CommandArgs) (*model.Co
 		return p.cmdError(args, "Unable to disconnect the bot account, only system admins can disconnect the bot account.")
 	}
 
-	if _, err := p.store.MattermostToTeamsUserID(p.userID); err != nil {
+	if _, err := p.store.MattermostToTeamsUserID(p.botID); err != nil {
 		return p.cmdSuccess(args, "Error: unable to find the connected bot account")
 	}
 
-	if err := p.store.DeleteUserInfo(p.userID); err != nil {
+	if err := p.store.DeleteUserInfo(p.botID); err != nil {
 		return p.cmdSuccess(args, fmt.Sprintf("Error: unable to disconnect the bot account, %s", err.Error()))
 	}
 

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -504,7 +504,7 @@ func TestExecuteDisconnectBotCommand(t *testing.T) {
 			ChannelId: model.NewId(),
 		}
 
-		err := th.p.store.SetUserInfo(th.p.botID, "bot_team_user_id", &oauth2.Token{AccessToken: "token", Expiry: time.Now().Add(10 * time.Minute)})
+		err := th.p.store.SetUserInfo(th.p.botUsertID, "bot_team_user_id", &oauth2.Token{AccessToken: "token", Expiry: time.Now().Add(10 * time.Minute)})
 
 		require.NoError(t, err)
 
@@ -886,7 +886,7 @@ func TestExecuteConnectBotCommand(t *testing.T) {
 			ChannelId: model.NewId(),
 		}
 
-		err := th.p.store.SetUserInfo(th.p.botID, "bot_team_user_id", &oauth2.Token{AccessToken: "token", Expiry: time.Now().Add(10 * time.Minute)})
+		err := th.p.store.SetUserInfo(th.p.botUsertID, "bot_team_user_id", &oauth2.Token{AccessToken: "token", Expiry: time.Now().Add(10 * time.Minute)})
 		require.NoError(t, err)
 
 		commandResponse, appErr := th.p.executeConnectBotCommand(args)

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -504,7 +504,7 @@ func TestExecuteDisconnectBotCommand(t *testing.T) {
 			ChannelId: model.NewId(),
 		}
 
-		err := th.p.store.SetUserInfo(th.p.userID, "bot_team_user_id", &oauth2.Token{AccessToken: "token", Expiry: time.Now().Add(10 * time.Minute)})
+		err := th.p.store.SetUserInfo(th.p.botID, "bot_team_user_id", &oauth2.Token{AccessToken: "token", Expiry: time.Now().Add(10 * time.Minute)})
 
 		require.NoError(t, err)
 
@@ -886,7 +886,7 @@ func TestExecuteConnectBotCommand(t *testing.T) {
 			ChannelId: model.NewId(),
 		}
 
-		err := th.p.store.SetUserInfo(th.p.userID, "bot_team_user_id", &oauth2.Token{AccessToken: "token", Expiry: time.Now().Add(10 * time.Minute)})
+		err := th.p.store.SetUserInfo(th.p.botID, "bot_team_user_id", &oauth2.Token{AccessToken: "token", Expiry: time.Now().Add(10 * time.Minute)})
 		require.NoError(t, err)
 
 		commandResponse, appErr := th.p.executeConnectBotCommand(args)

--- a/server/connect.go
+++ b/server/connect.go
@@ -93,7 +93,7 @@ func (p *Plugin) SendInviteMessage(user *model.User, pendingSince time.Time, cur
 		invitedUser.InvitePendingSince = currentTime
 	}
 
-	channel, err := p.apiClient.Channel.GetDirect(user.Id, p.botID)
+	channel, err := p.apiClient.Channel.GetDirect(user.Id, p.botUsertID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get bot DM channel with user_id %s", user.Id)
 	}
@@ -101,7 +101,7 @@ func (p *Plugin) SendInviteMessage(user *model.User, pendingSince time.Time, cur
 	message := fmt.Sprintf("@%s, you’re invited to use the Microsoft Teams connected experience for Mattermost. ", user.Username)
 	invitePost := &model.Post{
 		Message:   message,
-		UserId:    p.botID,
+		UserId:    p.botUsertID,
 		ChannelId: channel.Id,
 	}
 	if err := p.apiClient.Post.CreatePost(invitePost); err != nil {

--- a/server/connect.go
+++ b/server/connect.go
@@ -93,7 +93,7 @@ func (p *Plugin) SendInviteMessage(user *model.User, pendingSince time.Time, cur
 		invitedUser.InvitePendingSince = currentTime
 	}
 
-	channel, err := p.apiClient.Channel.GetDirect(user.Id, p.userID)
+	channel, err := p.apiClient.Channel.GetDirect(user.Id, p.botID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get bot DM channel with user_id %s", user.Id)
 	}
@@ -101,7 +101,7 @@ func (p *Plugin) SendInviteMessage(user *model.User, pendingSince time.Time, cur
 	message := fmt.Sprintf("@%s, you’re invited to use the Microsoft Teams connected experience for Mattermost. ", user.Username)
 	invitePost := &model.Post{
 		Message:   message,
-		UserId:    p.userID,
+		UserId:    p.botID,
 		ChannelId: channel.Id,
 	}
 	if err := p.apiClient.Post.CreatePost(invitePost); err != nil {

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -39,7 +39,7 @@ func (p *Plugin) UserWillLogIn(_ *plugin.Context, user *model.User) string {
 
 func (p *Plugin) MessageHasBeenDeleted(_ *plugin.Context, post *model.Post) {
 	if post.Props != nil {
-		if _, ok := post.Props["msteams_sync_"+p.botID].(bool); ok {
+		if _, ok := post.Props["msteams_sync_"+p.botUsertID].(bool); ok {
 			return
 		}
 	}
@@ -100,7 +100,7 @@ func (p *Plugin) MessageHasBeenPosted(_ *plugin.Context, post *model.Post) {
 	isDirectOrGroupMessage := channel.IsGroupOrDirect()
 
 	if post.Props != nil {
-		if _, ok := post.Props["msteams_sync_"+p.botID].(bool); ok {
+		if _, ok := post.Props["msteams_sync_"+p.botUsertID].(bool); ok {
 			return
 		}
 	}
@@ -629,7 +629,7 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 	text := post.Message
 	client, err := p.GetClientForUser(user.Id)
 	if err != nil {
-		client, err = p.GetClientForUser(p.botID)
+		client, err = p.GetClientForUser(p.botUsertID)
 		if err != nil {
 			return "", err
 		}
@@ -708,7 +708,7 @@ func (p *Plugin) Delete(teamID, channelID string, user *model.User, post *model.
 
 	client, err := p.GetClientForUser(user.Id)
 	if err != nil {
-		client, err = p.GetClientForUser(p.botID)
+		client, err = p.GetClientForUser(p.botUsertID)
 		if err != nil {
 			return err
 		}
@@ -778,7 +778,7 @@ func (p *Plugin) Update(teamID, channelID string, user *model.User, newPost *mod
 
 	client, err := p.GetClientForUser(user.Id)
 	if err != nil {
-		client, err = p.GetClientForUser(p.botID)
+		client, err = p.GetClientForUser(p.botUsertID)
 		if err != nil {
 			return err
 		}

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -39,7 +39,7 @@ func (p *Plugin) UserWillLogIn(_ *plugin.Context, user *model.User) string {
 
 func (p *Plugin) MessageHasBeenDeleted(_ *plugin.Context, post *model.Post) {
 	if post.Props != nil {
-		if _, ok := post.Props["msteams_sync_"+p.userID].(bool); ok {
+		if _, ok := post.Props["msteams_sync_"+p.botID].(bool); ok {
 			return
 		}
 	}
@@ -100,7 +100,7 @@ func (p *Plugin) MessageHasBeenPosted(_ *plugin.Context, post *model.Post) {
 	isDirectOrGroupMessage := channel.IsGroupOrDirect()
 
 	if post.Props != nil {
-		if _, ok := post.Props["msteams_sync_"+p.userID].(bool); ok {
+		if _, ok := post.Props["msteams_sync_"+p.botID].(bool); ok {
 			return
 		}
 	}
@@ -629,7 +629,7 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 	text := post.Message
 	client, err := p.GetClientForUser(user.Id)
 	if err != nil {
-		client, err = p.GetClientForUser(p.userID)
+		client, err = p.GetClientForUser(p.botID)
 		if err != nil {
 			return "", err
 		}
@@ -708,7 +708,7 @@ func (p *Plugin) Delete(teamID, channelID string, user *model.User, post *model.
 
 	client, err := p.GetClientForUser(user.Id)
 	if err != nil {
-		client, err = p.GetClientForUser(p.userID)
+		client, err = p.GetClientForUser(p.botID)
 		if err != nil {
 			return err
 		}
@@ -778,7 +778,7 @@ func (p *Plugin) Update(teamID, channelID string, user *model.User, newPost *mod
 
 	client, err := p.GetClientForUser(user.Id)
 	if err != nil {
-		client, err = p.GetClientForUser(p.userID)
+		client, err = p.GetClientForUser(p.botID)
 		if err != nil {
 			return err
 		}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -69,9 +69,9 @@ type Plugin struct {
 	stopSubscriptions func()
 	stopContext       context.Context
 
-	botID     string
-	remoteID  string
-	apiClient *pluginapi.Client
+	botUsertID string
+	remoteID   string
+	apiClient  *pluginapi.Client
 
 	store                     store.Store
 	subscriptionsClusterMutex *cluster.Mutex
@@ -138,7 +138,7 @@ func (p *Plugin) GetBufferSizeForStreaming() int {
 }
 
 func (p *Plugin) GetBotUserID() string {
-	return p.botID
+	return p.botUsertID
 }
 
 func (p *Plugin) GetSelectiveSync() bool {
@@ -481,7 +481,7 @@ func (p *Plugin) onActivate() error {
 		return err
 	}
 
-	p.botID, err = p.apiClient.Bot.EnsureBot(&model.Bot{
+	p.botUsertID, err = p.apiClient.Bot.EnsureBot(&model.Bot{
 		Username:    botUsername,
 		DisplayName: botDisplayName,
 		Description: "Created by the MS Teams Sync plugin.",
@@ -493,7 +493,7 @@ func (p *Plugin) onActivate() error {
 	p.remoteID, err = p.API.RegisterPluginForSharedChannels(model.RegisterPluginOpts{
 		Displayname:  pluginID,
 		PluginID:     pluginID,
-		CreatorID:    p.botID,
+		CreatorID:    p.botUsertID,
 		AutoShareDMs: false,
 		AutoInvited:  true,
 	})
@@ -550,7 +550,7 @@ func (p *Plugin) onActivate() error {
 				TeamId:    linkedChannel.MattermostTeamID,
 				Home:      true,
 				ReadOnly:  false,
-				CreatorId: p.botID,
+				CreatorId: p.botUsertID,
 				RemoteId:  p.remoteID,
 				ShareName: linkedChannel.MattermostChannelID,
 			})

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -69,7 +69,7 @@ type Plugin struct {
 	stopSubscriptions func()
 	stopContext       context.Context
 
-	userID    string
+	botID     string
 	remoteID  string
 	apiClient *pluginapi.Client
 
@@ -138,7 +138,7 @@ func (p *Plugin) GetBufferSizeForStreaming() int {
 }
 
 func (p *Plugin) GetBotUserID() string {
-	return p.userID
+	return p.botID
 }
 
 func (p *Plugin) GetSelectiveSync() bool {
@@ -481,7 +481,7 @@ func (p *Plugin) onActivate() error {
 		return err
 	}
 
-	p.userID, err = p.apiClient.Bot.EnsureBot(&model.Bot{
+	p.botID, err = p.apiClient.Bot.EnsureBot(&model.Bot{
 		Username:    botUsername,
 		DisplayName: botDisplayName,
 		Description: "Created by the MS Teams Sync plugin.",
@@ -493,7 +493,7 @@ func (p *Plugin) onActivate() error {
 	p.remoteID, err = p.API.RegisterPluginForSharedChannels(model.RegisterPluginOpts{
 		Displayname:  pluginID,
 		PluginID:     pluginID,
-		CreatorID:    p.userID,
+		CreatorID:    p.botID,
 		AutoShareDMs: false,
 		AutoInvited:  true,
 	})
@@ -550,7 +550,7 @@ func (p *Plugin) onActivate() error {
 				TeamId:    linkedChannel.MattermostTeamID,
 				Home:      true,
 				ReadOnly:  false,
-				CreatorId: p.userID,
+				CreatorId: p.botID,
 				RemoteId:  p.remoteID,
 				ShareName: linkedChannel.MattermostChannelID,
 			})

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -100,7 +100,7 @@ func newTestPlugin(t *testing.T) *Plugin {
 	plugin.apiHandler = NewAPI(plugin, plugin.store)
 
 	plugin.metricsService = mockMetricsService
-	plugin.botID = "bot-user-id"
+	plugin.botUsertID = "bot-user-id"
 	return plugin
 }
 

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -100,7 +100,7 @@ func newTestPlugin(t *testing.T) *Plugin {
 	plugin.apiHandler = NewAPI(plugin, plugin.store)
 
 	plugin.metricsService = mockMetricsService
-	plugin.userID = "bot-user-id"
+	plugin.botID = "bot-user-id"
 	return plugin
 }
 


### PR DESCRIPTION
#### Summary
Naming is king. Finally changing the `userID` property to `botUsertID`!

Not the most important PR... or is it?