### PR TITLE
[MM-58322] Add notification preference slash command

### DIFF
--- a/server/automute.go
+++ b/server/automute.go
@@ -113,14 +113,7 @@ func (p *Plugin) getAutomuteIsEnabledForUser(userID string) bool {
 
 // setAutomuteIsEnabledForUser sets a preference to track if we've muted all of the user's linked channels.
 func (p *Plugin) setAutomuteIsEnabledForUser(userID string, channelsAutomuted bool) error {
-	appErr := p.API.UpdatePreferencesForUser(userID, []model.Preference{
-		{
-			UserId:   userID,
-			Category: PreferenceCategoryPlugin,
-			Name:     PreferenceNameAutomuteEnabled,
-			Value:    strconv.FormatBool(channelsAutomuted),
-		},
-	})
+	appErr := p.updatePreferenceForUser(userID, PreferenceNameAutomuteEnabled, strconv.FormatBool(channelsAutomuted))
 	if appErr != nil {
 		return errors.Wrap(appErr, fmt.Sprintf("Unable to set preference to track that channels are automuted for user %s", userID))
 	}

--- a/server/command.go
+++ b/server/command.go
@@ -100,9 +100,9 @@ func getAutocompleteData(syncLinkedChannels bool) *model.AutocompleteData {
 
 	notification := model.NewAutocompleteData("notifications", "", "Enable or disable notifications from MSTeams. You must be connected to perform this action.")
 	notification.AddStaticListArgument("status", true, []model.AutocompleteListItem{
-		{Item: "status", HelpText: "Show current notification status"},
-		{Item: "on", HelpText: "Enable notifications"},
-		{Item: "off", HelpText: "Disable notifications"},
+		{Item: "status", HelpText: "Show current notification status."},
+		{Item: "on", HelpText: "Enable notifications."},
+		{Item: "off", HelpText: "Disable notifications."},
 	})
 	cmd.AddCommand(notification)
 

--- a/server/command.go
+++ b/server/command.go
@@ -649,12 +649,20 @@ func (p *Plugin) executeNotificationsCommand(args *model.CommandArgs, parameters
 		return p.cmdSuccess(args, fmt.Sprintf("Notifications from MSTeams are currently %s.", status))
 	case "on":
 		if !notificationPreferenceEnabled {
-			p.setNotificationPreference(args.UserId, true)
+			err := p.setNotificationPreference(args.UserId, true)
+			if err != nil {
+				p.API.LogWarn("unable to enable notifications", "error", err.Error())
+				return p.cmdError(args, "Error: Unable to enable notifications.")
+			}
 		}
 		return p.cmdSuccess(args, "Notifications from MSTeams are now enabled.")
 	case "off":
 		if notificationPreferenceEnabled {
 			p.setNotificationPreference(args.UserId, false)
+			if err != nil {
+				p.API.LogWarn("unable to disable notifications", "error", err.Error())
+				return p.cmdError(args, "Error: Unable to disable notifications.")
+			}
 		}
 		return p.cmdSuccess(args, "Notifications from MSTeams are now disabled.")
 	}

--- a/server/command.go
+++ b/server/command.go
@@ -103,13 +103,13 @@ func getAutocompleteData(syncLinkedChannels bool) *model.AutocompleteData {
 	promoteUser.RoleID = model.SystemAdminRoleId
 	cmd.AddCommand(promoteUser)
 
-	notification := model.NewAutocompleteData("notifications", "", "Enable or disable notifications from MSTeams. You must be connected to perform this action.")
-	notification.AddStaticListArgument("status", true, []model.AutocompleteListItem{
+	notifications := model.NewAutocompleteData("notifications", "", "Enable or disable notifications from MSTeams. You must be connected to perform this action.")
+	notifications.AddStaticListArgument("status", true, []model.AutocompleteListItem{
 		{Item: "status", HelpText: "Show current notification status."},
 		{Item: "on", HelpText: "Enable notifications."},
 		{Item: "off", HelpText: "Disable notifications."},
 	})
-	cmd.AddCommand(notification)
+	cmd.AddCommand(notifications)
 
 	return cmd
 }
@@ -634,7 +634,7 @@ func (p *Plugin) executeStatusCommand(args *model.CommandArgs) (*model.CommandRe
 
 func (p *Plugin) executeNotificationsCommand(args *model.CommandArgs, parameters []string) (*model.CommandResponse, *model.AppError) {
 	if len(parameters) != 1 {
-		return p.cmdSuccess(args, "Invalid notification command, one argument is required.")
+		return p.cmdSuccess(args, "Invalid notifications command, one argument is required.")
 	}
 
 	isConnected, err := p.isUserConnected(args.UserId)

--- a/server/command.go
+++ b/server/command.go
@@ -172,9 +172,9 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 	}
 
 	if p.getConfiguration().SyncLinkedChannels {
-		return p.cmdError(args, "Unknown command. Valid options: link, unlink, show, show-links, connect, connect-bot, status, disconnect, disconnect-bot, promote and notification.")
+		return p.cmdError(args, "Unknown command. Valid options: link, unlink, show, show-links, connect, connect-bot, status, disconnect, disconnect-bot, promote and notifications.")
 	}
-	return p.cmdError(args, "Unknown command. Valid options: connect, connect-bot, status, disconnect, disconnect-bot and promote and notification.")
+	return p.cmdError(args, "Unknown command. Valid options: connect, connect-bot, status, disconnect, disconnect-bot and promote and notifications.")
 }
 
 func (p *Plugin) executeLinkCommand(args *model.CommandArgs, parameters []string) (*model.CommandResponse, *model.AppError) {

--- a/server/command.go
+++ b/server/command.go
@@ -656,7 +656,7 @@ func (p *Plugin) executeNotificationsCommand(args *model.CommandArgs, parameters
 		return p.cmdSuccess(args, fmt.Sprintf("Notifications from MSTeams are currently %s.", status))
 	case "on":
 		if !notificationPreferenceEnabled {
-			err := p.setNotificationPreference(args.UserId, true)
+			err = p.setNotificationPreference(args.UserId, true)
 			if err != nil {
 				p.API.LogWarn("unable to enable notifications", "error", err.Error())
 				return p.cmdError(args, "Error: Unable to enable notifications.")
@@ -665,7 +665,7 @@ func (p *Plugin) executeNotificationsCommand(args *model.CommandArgs, parameters
 		return p.cmdSuccess(args, "Notifications from MSTeams are now enabled.")
 	case "off":
 		if notificationPreferenceEnabled {
-			p.setNotificationPreference(args.UserId, false)
+			err = p.setNotificationPreference(args.UserId, false)
 			if err != nil {
 				p.API.LogWarn("unable to disable notifications", "error", err.Error())
 				return p.cmdError(args, "Error: Unable to disable notifications.")

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -1061,6 +1061,35 @@ func TestGetAutocompleteData(t *testing.T) {
 						},
 						SubCommands: []*model.AutocompleteData{},
 					},
+					{
+						Trigger:  "notifications",
+						HelpText: "Enable or disable notifications from MSTeams. You must be connected to perform this action.",
+						RoleID:   model.SystemUserRoleId,
+						Arguments: []*model.AutocompleteArg{
+							{
+								Required: true,
+								Type:     model.AutocompleteArgTypeStaticList,
+								HelpText: "status",
+								Data: &model.AutocompleteStaticListArg{
+									PossibleArguments: []model.AutocompleteListItem{
+										{
+											Item:     "status",
+											HelpText: "Show current notification status.",
+										},
+										{
+											Item:     "on",
+											HelpText: "Enable notifications.",
+										},
+										{
+											Item:     "off",
+											HelpText: "Disable notifications.",
+										},
+									},
+								},
+							},
+						},
+						SubCommands: []*model.AutocompleteData{},
+					},
 				},
 			},
 		},
@@ -1130,6 +1159,35 @@ func TestGetAutocompleteData(t *testing.T) {
 								Data: &model.AutocompleteTextArg{
 									Hint:    "new username",
 									Pattern: `^[a-z0-9\.\-_:]+$`,
+								},
+							},
+						},
+						SubCommands: []*model.AutocompleteData{},
+					},
+					{
+						Trigger:  "notifications",
+						HelpText: "Enable or disable notifications from MSTeams. You must be connected to perform this action.",
+						RoleID:   model.SystemUserRoleId,
+						Arguments: []*model.AutocompleteArg{
+							{
+								Required: true,
+								Type:     model.AutocompleteArgTypeStaticList,
+								HelpText: "status",
+								Data: &model.AutocompleteStaticListArg{
+									PossibleArguments: []model.AutocompleteListItem{
+										{
+											Item:     "status",
+											HelpText: "Show current notification status.",
+										},
+										{
+											Item:     "on",
+											HelpText: "Enable notifications.",
+										},
+										{
+											Item:     "off",
+											HelpText: "Disable notifications.",
+										},
+									},
 								},
 							},
 						},

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -1531,7 +1531,6 @@ func TestNotificationCommand(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-
 				if tc.enabled != nil {
 					err := th.p.setNotificationPreference(user1.Id, *tc.enabled)
 					require.Nil(t, err)
@@ -1560,7 +1559,6 @@ func TestNotificationCommand(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-
 				if tc.enabled != nil {
 					err := th.p.setNotificationPreference(user1.Id, *tc.enabled)
 					require.Nil(t, err)

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -1378,3 +1378,143 @@ func TestStatusCommand(t *testing.T) {
 		assertEphemeralResponse(th, t, args, "Your account is connected to Teams.")
 	})
 }
+
+func TestNotificationCommand(t *testing.T) {
+	th := setupTestHelper(t)
+
+	team := th.SetupTeam(t)
+	user1 := th.SetupUser(t, team)
+	args := &model.CommandArgs{
+		UserId:    user1.Id,
+		ChannelId: model.NewId(),
+	}
+
+	th.SetupWebsocketClientForUser(t, user1.Id)
+
+	reset := func(th *testHelper, t *testing.T, connectUser bool) {
+		t.Helper()
+		th.Reset(t)
+
+		if connectUser {
+			th.ConnectUser(t, user1.Id)
+		}
+
+		err := th.p.API.DeletePreferencesForUser(user1.Id, []model.Preference{{
+			UserId:   user1.Id,
+			Category: PreferenceCategoryPlugin,
+			Name:     storemodels.PreferenceNameNotification,
+		}})
+		require.Nil(t, err)
+	}
+
+	t.Run("not connected user should be rejected", func(t *testing.T) {
+		reset(th, t, false)
+		subCommands := []string{"status", "on", "off"}
+		for _, subCommand := range subCommands {
+			t.Run("subcommand "+subCommand, func(t *testing.T) {
+				commandResponse, appErr := th.p.executeNotificationsCommand(args, []string{subCommand})
+				require.Nil(t, appErr)
+				assertNoCommandResponse(t, commandResponse)
+				assertEphemeralResponse(th, t, args, "Error: Your account is not connected to Teams. To use this feature, please connect your account with `/msteams connect`.")
+			})
+		}
+	})
+
+	t.Run("status", func(t *testing.T) {
+		t.Run("connected user should get the appropriate message", func(t *testing.T) {
+			cases := []struct {
+				name     string
+				enabled  *bool
+				expected string
+			}{
+				{
+					name:     "enabled",
+					enabled:  model.NewBool(true),
+					expected: "Notifications from MSTeams are currently enabled.",
+				},
+				{
+					name:     "disabled",
+					enabled:  model.NewBool(false),
+					expected: "Notifications from MSTeams are currently disabled.",
+				},
+				{
+					name:     "not set",
+					enabled:  nil,
+					expected: "Notifications from MSTeams are currently disabled.",
+				},
+			}
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					reset(th, t, true)
+					if tc.enabled != nil {
+						err := th.p.setNotificationPreference(user1.Id, *tc.enabled)
+						require.Nil(t, err)
+					}
+
+					commandResponse, appErr := th.p.executeNotificationsCommand(args, []string{"status"})
+					require.Nil(t, appErr)
+					assertNoCommandResponse(t, commandResponse)
+					assertEphemeralResponse(th, t, args, tc.expected)
+				})
+			}
+		})
+	})
+
+	t.Run("on", func(t *testing.T) {
+		reset(th, t, true)
+
+		cases := []struct {
+			name    string
+			enabled *bool
+		}{
+			{name: "was enabled", enabled: model.NewBool(true)},
+			{name: "was disabled", enabled: model.NewBool(false)},
+			{name: "was not set", enabled: nil},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+
+				if tc.enabled != nil {
+					err := th.p.setNotificationPreference(user1.Id, *tc.enabled)
+					require.Nil(t, err)
+				}
+
+				commandResponse, appErr := th.p.executeNotificationsCommand(args, []string{"on"})
+				require.Nil(t, appErr)
+				assertNoCommandResponse(t, commandResponse)
+				assertEphemeralResponse(th, t, args, "Notifications from MSTeams are now enabled.")
+
+				require.True(t, th.p.getNotificationPreference(user1.Id))
+			})
+		}
+	})
+
+	t.Run("off", func(t *testing.T) {
+		reset(th, t, true)
+
+		cases := []struct {
+			name    string
+			enabled *bool
+		}{
+			{name: "was enabled", enabled: model.NewBool(true)},
+			{name: "was disabled", enabled: model.NewBool(false)},
+			{name: "was not set", enabled: nil},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+
+				if tc.enabled != nil {
+					err := th.p.setNotificationPreference(user1.Id, *tc.enabled)
+					require.Nil(t, err)
+				}
+
+				commandResponse, appErr := th.p.executeNotificationsCommand(args, []string{"off"})
+				require.Nil(t, appErr)
+				assertNoCommandResponse(t, commandResponse)
+				assertEphemeralResponse(th, t, args, "Notifications from MSTeams are now disabled.")
+
+				require.False(t, th.p.getNotificationPreference(user1.Id))
+			})
+		}
+	})
+}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -87,6 +87,8 @@ type Plugin struct {
 	metricsService         metrics.Metrics
 	metricsHandler         http.Handler
 	metricsJob             *cluster.Job
+
+	subCommands []string
 }
 
 func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Request) {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -88,7 +88,8 @@ type Plugin struct {
 	metricsHandler         http.Handler
 	metricsJob             *cluster.Job
 
-	subCommands []string
+	subCommands      []string
+	subCommandsMutex sync.RWMutex
 }
 
 func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Request) {

--- a/server/preferences.go
+++ b/server/preferences.go
@@ -41,7 +41,7 @@ func (p *Plugin) setPrimaryPlatform(userID string, primaryPlatform string) error
 
 func (p *Plugin) getNotificationPreference(userID string) bool {
 	// this call returns a generic error if the preference does not exist,
-	// we can omit the error check here and let the code assume it's on turned on
+	// we can omit the error check here and return off by default
 	pref, _ := p.API.GetPreferenceForUser(userID, PreferenceCategoryPlugin, storemodels.PreferenceNameNotification)
 	return pref.Value == storemodels.PreferenceValueNotificationOn
 }

--- a/server/preferences.go
+++ b/server/preferences.go
@@ -52,9 +52,9 @@ func (p *Plugin) setNotificationPreference(userID string, enable bool) error {
 		value = storemodels.PreferenceValueNotificationOn
 	}
 
-	err := p.updatePreferenceForUser(userID, storemodels.PreferenceNameNotification, value)
-	if err != nil {
-		return fmt.Errorf("failed to set notification status: %w", err)
+	appErr := p.updatePreferenceForUser(userID, storemodels.PreferenceNameNotification, value)
+	if appErr != nil {
+		return fmt.Errorf("failed to set notification status: %w", appErr)
 	}
 
 	return nil

--- a/server/preferences.go
+++ b/server/preferences.go
@@ -44,3 +44,29 @@ func (p *Plugin) setPrimaryPlatform(userID string, primaryPlatform string) error
 func (p *Plugin) GetPreferenceCategoryName() string {
 	return PreferenceCategoryPlugin
 }
+
+func (p *Plugin) getNotificationPreference(userID string) bool {
+	// this call returns a generic error if the preference does not exist,
+	// we can omit the error check here and let the code assume it's on turned on
+	pref, _ := p.API.GetPreferenceForUser(userID, PreferenceCategoryPlugin, storemodels.PreferenceNameNotification)
+	return pref.Value == storemodels.PreferenceValueNotificationOn
+}
+
+func (p *Plugin) setNotificationPreference(userID string, enable bool) error {
+	value := storemodels.PreferenceValueNotificationOff
+	if enable {
+		value = storemodels.PreferenceValueNotificationOn
+	}
+
+	err := p.API.UpdatePreferencesForUser(userID, []model.Preference{{
+		UserId:   userID,
+		Category: PreferenceCategoryPlugin,
+		Name:     storemodels.PreferenceNameNotification,
+		Value:    value,
+	}})
+	if err != nil {
+		return fmt.Errorf("failed to set notification status: %w", err)
+	}
+
+	return nil
+}

--- a/server/preferences.go
+++ b/server/preferences.go
@@ -11,6 +11,10 @@ const (
 	PreferenceCategoryPlugin = "pp_" + pluginID
 )
 
+func (p *Plugin) GetPreferenceCategoryName() string {
+	return PreferenceCategoryPlugin
+}
+
 // getPrimaryPlatform returns the user's primary platform preference.
 func (p *Plugin) getPrimaryPlatform(userID string) string {
 	pref, appErr := p.API.GetPreferenceForUser(userID, PreferenceCategoryPlugin, storemodels.PreferenceNamePlatform)
@@ -28,21 +32,7 @@ func (p *Plugin) setPrimaryPlatform(userID string, primaryPlatform string) error
 		return fmt.Errorf("invalid primary platform: %s", primaryPlatform)
 	}
 
-	appErr := p.API.UpdatePreferencesForUser(userID, []model.Preference{{
-		UserId:   userID,
-		Category: PreferenceCategoryPlugin,
-		Name:     storemodels.PreferenceNamePlatform,
-		Value:    primaryPlatform,
-	}})
-	if appErr != nil {
-		return appErr
-	}
-
-	return nil
-}
-
-func (p *Plugin) GetPreferenceCategoryName() string {
-	return PreferenceCategoryPlugin
+	return p.updatePreferenceForUser(userID, storemodels.PreferenceNamePlatform, primaryPlatform)
 }
 
 func (p *Plugin) getNotificationPreference(userID string) bool {
@@ -58,15 +48,19 @@ func (p *Plugin) setNotificationPreference(userID string, enable bool) error {
 		value = storemodels.PreferenceValueNotificationOn
 	}
 
-	err := p.API.UpdatePreferencesForUser(userID, []model.Preference{{
-		UserId:   userID,
-		Category: PreferenceCategoryPlugin,
-		Name:     storemodels.PreferenceNameNotification,
-		Value:    value,
-	}})
+	err := p.updatePreferenceForUser(userID, storemodels.PreferenceNameNotification, value)
 	if err != nil {
 		return fmt.Errorf("failed to set notification status: %w", err)
 	}
 
 	return nil
+}
+
+func (p *Plugin) updatePreferenceForUser(userID string, name string, value string) *model.AppError {
+	return p.API.UpdatePreferencesForUser(userID, []model.Preference{{
+		UserId:   userID,
+		Category: PreferenceCategoryPlugin,
+		Name:     name,
+		Value:    value,
+	}})
 }

--- a/server/preferences.go
+++ b/server/preferences.go
@@ -32,7 +32,11 @@ func (p *Plugin) setPrimaryPlatform(userID string, primaryPlatform string) error
 		return fmt.Errorf("invalid primary platform: %s", primaryPlatform)
 	}
 
-	return p.updatePreferenceForUser(userID, storemodels.PreferenceNamePlatform, primaryPlatform)
+	appErr := p.updatePreferenceForUser(userID, storemodels.PreferenceNamePlatform, primaryPlatform)
+	if appErr != nil {
+		return appErr
+	}
+	return nil
 }
 
 func (p *Plugin) getNotificationPreference(userID string) bool {

--- a/server/preferences_test.go
+++ b/server/preferences_test.go
@@ -11,11 +11,12 @@ import (
 func TestGetNotificationStatus(t *testing.T) {
 	th := setupTestHelper(t)
 
+	team := th.SetupTeam(t)
+	user := th.SetupUser(t, team)
+
 	setup := func(t *testing.T) string {
 		t.Helper()
 
-		team := th.SetupTeam(t)
-		user := th.SetupUser(t, team)
 		err := th.p.API.DeletePreferencesForUser(user.Id, []model.Preference{
 			{UserId: user.Id, Category: PreferenceCategoryPlugin, Name: storemodels.PreferenceNameNotification},
 		})
@@ -35,14 +36,7 @@ func TestGetNotificationStatus(t *testing.T) {
 		assert := require.New(t)
 		userID := setup(t)
 
-		err := th.p.API.UpdatePreferencesForUser(userID, []model.Preference{
-			{
-				UserId:   userID,
-				Category: PreferenceCategoryPlugin,
-				Name:     storemodels.PreferenceNameNotification,
-				Value:    storemodels.PreferenceValueNotificationOff,
-			},
-		})
+		err := th.p.updatePreferenceForUser(userID, storemodels.PreferenceNameNotification, storemodels.PreferenceValueNotificationOff)
 		assert.Nil(err)
 
 		assert.False(th.p.getNotificationPreference(userID))
@@ -52,14 +46,7 @@ func TestGetNotificationStatus(t *testing.T) {
 		assert := require.New(t)
 		userID := setup(t)
 
-		err := th.p.API.UpdatePreferencesForUser(userID, []model.Preference{
-			{
-				UserId:   userID,
-				Category: PreferenceCategoryPlugin,
-				Name:     storemodels.PreferenceNameNotification,
-				Value:    storemodels.PreferenceValueNotificationOn,
-			},
-		})
+		err := th.p.updatePreferenceForUser(userID, storemodels.PreferenceNameNotification, storemodels.PreferenceValueNotificationOn)
 		assert.Nil(err)
 
 		assert.True(th.p.getNotificationPreference(userID))
@@ -69,34 +56,27 @@ func TestGetNotificationStatus(t *testing.T) {
 func TestSetNotificationStatus(t *testing.T) {
 	th := setupTestHelper(t)
 
-	setup := func(t *testing.T) string {
-		t.Helper()
-
-		team := th.SetupTeam(t)
-		user := th.SetupUser(t, team)
-		return user.Id
-	}
+	team := th.SetupTeam(t)
+	user := th.SetupUser(t, team)
 
 	t.Run("set to true should update the preference to on", func(t *testing.T) {
 		assert := require.New(t)
-		userID := setup(t)
 
-		err := th.p.setNotificationPreference(userID, true)
+		err := th.p.setNotificationPreference(user.Id, true)
 		assert.Nil(err)
 
-		pref, err := th.p.API.GetPreferenceForUser(userID, PreferenceCategoryPlugin, storemodels.PreferenceNameNotification)
+		pref, err := th.p.API.GetPreferenceForUser(user.Id, PreferenceCategoryPlugin, storemodels.PreferenceNameNotification)
 		assert.Nil(err)
 		assert.Equal(storemodels.PreferenceValueNotificationOn, pref.Value)
 	})
 
 	t.Run("set to false should update the preference to off", func(t *testing.T) {
 		assert := require.New(t)
-		userID := setup(t)
 
-		err := th.p.setNotificationPreference(userID, false)
+		err := th.p.setNotificationPreference(user.Id, false)
 		assert.Nil(err)
 
-		pref, err := th.p.API.GetPreferenceForUser(userID, PreferenceCategoryPlugin, storemodels.PreferenceNameNotification)
+		pref, err := th.p.API.GetPreferenceForUser(user.Id, PreferenceCategoryPlugin, storemodels.PreferenceNameNotification)
 		assert.Nil(err)
 		assert.Equal(storemodels.PreferenceValueNotificationOff, pref.Value)
 	})

--- a/server/preferences_test.go
+++ b/server/preferences_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-msteams/server/store/storemodels"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetNotificationStatus(t *testing.T) {
+	th := setupTestHelper(t)
+
+	setup := func(t *testing.T) string {
+		t.Helper()
+
+		team := th.SetupTeam(t)
+		user := th.SetupUser(t, team)
+		err := th.p.API.DeletePreferencesForUser(user.Id, []model.Preference{
+			{UserId: user.Id, Category: PreferenceCategoryPlugin, Name: storemodels.PreferenceNameNotification},
+		})
+		require.Nil(t, err)
+
+		return user.Id
+	}
+
+	t.Run("user without the preference should return false", func(t *testing.T) {
+		assert := require.New(t)
+		userID := setup(t)
+
+		assert.False(th.p.getNotificationPreference(userID))
+	})
+
+	t.Run("user with the preference set to off should return false", func(t *testing.T) {
+		assert := require.New(t)
+		userID := setup(t)
+
+		err := th.p.API.UpdatePreferencesForUser(userID, []model.Preference{
+			{
+				UserId:   userID,
+				Category: PreferenceCategoryPlugin,
+				Name:     storemodels.PreferenceNameNotification,
+				Value:    storemodels.PreferenceValueNotificationOff,
+			},
+		})
+		assert.Nil(err)
+
+		assert.False(th.p.getNotificationPreference(userID))
+	})
+
+	t.Run("user with the preference set to on should return true", func(t *testing.T) {
+		assert := require.New(t)
+		userID := setup(t)
+
+		err := th.p.API.UpdatePreferencesForUser(userID, []model.Preference{
+			{
+				UserId:   userID,
+				Category: PreferenceCategoryPlugin,
+				Name:     storemodels.PreferenceNameNotification,
+				Value:    storemodels.PreferenceValueNotificationOn,
+			},
+		})
+		assert.Nil(err)
+
+		assert.True(th.p.getNotificationPreference(userID))
+	})
+}
+
+func TestSetNotificationStatus(t *testing.T) {
+	th := setupTestHelper(t)
+
+	setup := func(t *testing.T) string {
+		t.Helper()
+
+		team := th.SetupTeam(t)
+		user := th.SetupUser(t, team)
+		return user.Id
+	}
+
+	t.Run("set to true should update the preference to on", func(t *testing.T) {
+		assert := require.New(t)
+		userID := setup(t)
+
+		err := th.p.setNotificationPreference(userID, true)
+		assert.Nil(err)
+
+		pref, err := th.p.API.GetPreferenceForUser(userID, PreferenceCategoryPlugin, storemodels.PreferenceNameNotification)
+		assert.Nil(err)
+		assert.Equal(storemodels.PreferenceValueNotificationOn, pref.Value)
+	})
+
+	t.Run("set to false should update the preference to off", func(t *testing.T) {
+		assert := require.New(t)
+		userID := setup(t)
+
+		err := th.p.setNotificationPreference(userID, false)
+		assert.Nil(err)
+
+		pref, err := th.p.API.GetPreferenceForUser(userID, PreferenceCategoryPlugin, storemodels.PreferenceNameNotification)
+		assert.Nil(err)
+		assert.Equal(storemodels.PreferenceValueNotificationOff, pref.Value)
+	})
+}

--- a/server/store/storemodels/storemodels.go
+++ b/server/store/storemodels/storemodels.go
@@ -11,7 +11,7 @@ const (
 	PreferenceValuePlatformMSTeams = "msteams"
 
 	// Notification preferences
-	PreferenceNameNotification     = "notification_status"
+	PreferenceNameNotification     = "notifications"
 	PreferenceValueNotificationOn  = "1"
 	PreferenceValueNotificationOff = "0"
 )

--- a/server/store/storemodels/storemodels.go
+++ b/server/store/storemodels/storemodels.go
@@ -12,8 +12,8 @@ const (
 
 	// Notification preferences
 	PreferenceNameNotification     = "notifications"
-	PreferenceValueNotificationOn  = "1"
-	PreferenceValueNotificationOff = "0"
+	PreferenceValueNotificationOn  = "on"
+	PreferenceValueNotificationOff = "off"
 )
 
 type ChannelLink struct {

--- a/server/store/storemodels/storemodels.go
+++ b/server/store/storemodels/storemodels.go
@@ -9,6 +9,11 @@ const (
 	PreferenceNamePlatform         = "platform"
 	PreferenceValuePlatformMM      = "mattermost"
 	PreferenceValuePlatformMSTeams = "msteams"
+
+	// Notification preferences
+	PreferenceNameNotification     = "notification_status"
+	PreferenceValueNotificationOn  = "1"
+	PreferenceValueNotificationOff = "0"
 )
 
 type ChannelLink struct {


### PR DESCRIPTION
#### Summary
This PR introduces the preference for the new notification feature. the UI will come in a future PR (probably right after this is merged), we started with the slash command to get something quickly.

- adds a slash command to allow the user to configure it.
- add methods to set/get the preference for the user

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-58322