### PR TITLE
Remove FOR UPDATE from read-only transactions

### DIFF
--- a/server/store/sqlstore/store.go
+++ b/server/store/sqlstore/store.go
@@ -287,7 +287,7 @@ func (s *SQLStore) mattermostToTeamsUserID(db sq.BaseRunner, userID string) (str
 
 //db:withReplica
 func (s *SQLStore) getPostInfoByMSTeamsID(db sq.BaseRunner, chatID string, postID string) (*storemodels.PostInfo, error) {
-	query := s.getQueryBuilder(db).Select("mmPostID, msTeamsLastUpdateAt").From(postsTableName).Where(sq.Eq{"msTeamsPostID": postID, "msTeamsChannelID": chatID}).Suffix("FOR UPDATE")
+	query := s.getQueryBuilder(db).Select("mmPostID, msTeamsLastUpdateAt").From(postsTableName).Where(sq.Eq{"msTeamsPostID": postID, "msTeamsChannelID": chatID})
 	row := query.QueryRow()
 	var lastUpdateAt int64
 	postInfo := storemodels.PostInfo{
@@ -304,7 +304,7 @@ func (s *SQLStore) getPostInfoByMSTeamsID(db sq.BaseRunner, chatID string, postI
 
 //db:withReplica
 func (s *SQLStore) getPostInfoByMattermostID(db sq.BaseRunner, postID string) (*storemodels.PostInfo, error) {
-	query := s.getQueryBuilder(db).Select("msTeamsPostID, msTeamsChannelID, msTeamsLastUpdateAt").From(postsTableName).Where(sq.Eq{"mmPostID": postID}).Suffix("FOR UPDATE")
+	query := s.getQueryBuilder(db).Select("msTeamsPostID, msTeamsChannelID, msTeamsLastUpdateAt").From(postsTableName).Where(sq.Eq{"mmPostID": postID})
 	row := query.QueryRow()
 	var lastUpdateAt int64
 	postInfo := storemodels.PostInfo{
@@ -775,7 +775,7 @@ func (s *SQLStore) deleteSubscription(db sq.BaseRunner, subscriptionID string) e
 
 //db:withReplica
 func (s *SQLStore) getChannelSubscription(db sq.BaseRunner, subscriptionID string) (*storemodels.ChannelSubscription, error) {
-	row := s.getQueryBuilder(db).Select("subscriptionID, msTeamsChannelID, msTeamsTeamID, secret, expiresOn, certificate").From(subscriptionsTableName).Where(sq.Eq{"subscriptionID": subscriptionID, "type": subscriptionTypeChannel}).Suffix("FOR UPDATE").QueryRow()
+	row := s.getQueryBuilder(db).Select("subscriptionID, msTeamsChannelID, msTeamsTeamID, secret, expiresOn, certificate").From(subscriptionsTableName).Where(sq.Eq{"subscriptionID": subscriptionID, "type": subscriptionTypeChannel}).QueryRow()
 	var subscription storemodels.ChannelSubscription
 	var expiresOn int64
 	var certificate *string


### PR DESCRIPTION
#### Summary
In the past, we relied on transactions at the application layer, and had embedded `FOR UPDATE` additions to various queries in support of same. This stopped working once we added support for read replicas and marked these APIs with `db:withReplica`. But notably, this was only an issue when a read replica is actually setup and the database enforces read-only semantics.

Since we stopped using transactions this way, these `FOR UPDATE` additions are redundant and can simply be removed.

![CleanShot 2024-05-28 at 12 24 45@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/c8fd1507-3d15-4957-b68b-b830766c6566)

#### Ticket Link
None.