### PR TITLE
MM-58287: track notification metrics

### DIFF
--- a/server/metrics/mocks/Metrics.go
+++ b/server/metrics/mocks/Metrics.go
@@ -150,6 +150,11 @@ func (_m *Metrics) ObserveMessageDelay(action string, source string, isDirectOrG
 	_m.Called(action, source, isDirectOrGroupMessage, delay)
 }
 
+// ObserveNotification provides a mock function with given fields: isGroupChat, hasAttachments
+func (_m *Metrics) ObserveNotification(isGroupChat bool, hasAttachments bool) {
+	_m.Called(isGroupChat, hasAttachments)
+}
+
 // ObserveOAuthTokenInvalidated provides a mock function with given fields:
 func (_m *Metrics) ObserveOAuthTokenInvalidated() {
 	_m.Called()

--- a/server/notifications.go
+++ b/server/notifications.go
@@ -46,6 +46,7 @@ func (ah *ActivityHandler) handleCreatedActivityNotification(msg *clientmodels.M
 		}
 		notifiedUsers = append(notifiedUsers, mattermostUserID)
 
+		ah.plugin.metricsService.ObserveNotification(len(chat.Members) >= 3, attachmentCount > 0)
 		ah.plugin.notifyChat(
 			mattermostUserID,
 			msg.UserDisplayName,


### PR DESCRIPTION
#### Summary
Keep track of the number of notifications emitted to users, including whether or not they are for group chats (>= members) and have any attachments.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-58299