### PR TITLE
MM-58483: handle empty notification messages better

### DIFF
--- a/server/bot_messages.go
+++ b/server/bot_messages.go
@@ -135,8 +135,13 @@ func (p *Plugin) makeWelcomeMessageWithNotificationActionPost() *model.Post {
 	}
 }
 
-// notifyMessage sends the given receipient a notification of a chat received on Teams.
-func (p *Plugin) notifyChat(recipientUserID string, actorDisplayName string, chatTopic string, chatSize int, chatLink string, message string, attachmentCount int) {
+// formatNotificationMessage formats the message about a notification of a chat received on Teams.
+func formatNotificationMessage(actorDisplayName string, chatTopic string, chatSize int, chatLink string, message string, attachmentCount int) string {
+	message = strings.TrimSpace(message)
+	if message == "" && attachmentCount == 0 {
+		return ""
+	}
+
 	var preamble string
 
 	var chatTopicDesc string
@@ -145,7 +150,7 @@ func (p *Plugin) notifyChat(recipientUserID string, actorDisplayName string, cha
 	}
 
 	if chatSize <= 1 {
-		return
+		return ""
 	} else if chatSize == 2 {
 		preamble = fmt.Sprintf("**%s** messaged you in an [MS Teams chat%s](%s):", actorDisplayName, chatTopicDesc, chatLink)
 	} else if chatSize == 3 {
@@ -153,23 +158,38 @@ func (p *Plugin) notifyChat(recipientUserID string, actorDisplayName string, cha
 	} else {
 		preamble = fmt.Sprintf("**%s** messaged you and %d other users in an [MS Teams group chat%s](%s):", actorDisplayName, chatSize-2, chatTopicDesc, chatLink)
 	}
+	preamble += "\n"
 
-	message = "> " + strings.ReplaceAll(message, "\n", "\n>")
+	if message != "" {
+		message = "> " + strings.ReplaceAll(message, "\n", "\n> ")
+	}
 
 	attachmentsNotice := ""
 	if attachmentCount > 0 {
+		if len(message) > 0 {
+			attachmentsNotice += "\n"
+		}
 		attachmentsNotice += "\n*"
 		if attachmentCount == 1 {
 			attachmentsNotice += "This message was originally sent with one attachment."
 		} else {
 			attachmentsNotice += fmt.Sprintf("This message was originally sent with %d attachments.", attachmentCount)
 		}
-		attachmentsNotice += "*\n"
+		attachmentsNotice += "*"
 	}
 
-	formattedMessage := fmt.Sprintf(`%s
-%s
-%s`, preamble, message, attachmentsNotice)
+	formattedMessage := fmt.Sprintf(`%s%s%s`, preamble, message, attachmentsNotice)
+
+	return formattedMessage
+}
+
+// notifyMessage sends the given receipient a notification of a chat received on Teams.
+func (p *Plugin) notifyChat(recipientUserID string, actorDisplayName string, chatTopic string, chatSize int, chatLink string, message string, attachmentCount int) {
+	formattedMessage := formatNotificationMessage(actorDisplayName, chatTopic, chatSize, chatLink, message, attachmentCount)
+
+	if formattedMessage == "" {
+		return
+	}
 
 	if err := p.botSendDirectMessage(recipientUserID, formattedMessage); err != nil {
 		p.GetAPI().LogWarn("Failed to send notification message", "user_id", recipientUserID, "error", err)

--- a/server/notifications_test.go
+++ b/server/notifications_test.go
@@ -1,0 +1,370 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatNotificationMessage(t *testing.T) {
+	testCases := []struct {
+		Description string
+
+		ActorDisplayName string
+		ChatTopic        string
+		ChatSize         int
+		ChatLink         string
+		Message          string
+		AttachmentCount  int
+		ExpectedMessage  string
+	}{
+		{
+			Description: "empty message, no attachments",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "",
+			ChatSize:         2,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "",
+			AttachmentCount:  0,
+
+			ExpectedMessage: ``,
+		},
+		{
+			Description: "empty message, one attachment",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "",
+			ChatSize:         2,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "",
+			AttachmentCount:  1,
+
+			ExpectedMessage: `**Sender** messaged you in an [MS Teams chat](http://teams.microsoft.com/chat/1):
+
+*This message was originally sent with one attachment.*`,
+		},
+		{
+			Description: "empty message, more than one attachment",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "",
+			ChatSize:         2,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "",
+			AttachmentCount:  2,
+
+			ExpectedMessage: `**Sender** messaged you in an [MS Teams chat](http://teams.microsoft.com/chat/1):
+
+*This message was originally sent with 2 attachments.*`,
+		},
+		{
+			Description: "chat message, no attachments, no topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "",
+			ChatSize:         2,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  0,
+
+			ExpectedMessage: `**Sender** messaged you in an [MS Teams chat](http://teams.microsoft.com/chat/1):
+> Hello!`,
+		},
+		{
+			Description: "chat message, one attachment, no topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "",
+			ChatSize:         2,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  1,
+
+			ExpectedMessage: `**Sender** messaged you in an [MS Teams chat](http://teams.microsoft.com/chat/1):
+> Hello!
+
+*This message was originally sent with one attachment.*`,
+		},
+		{
+			Description: "chat message, more than one attachment, no topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "",
+			ChatSize:         2,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  2,
+
+			ExpectedMessage: `**Sender** messaged you in an [MS Teams chat](http://teams.microsoft.com/chat/1):
+> Hello!
+
+*This message was originally sent with 2 attachments.*`,
+		},
+		{
+			Description: "chat message, no attachments, has topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "Topic",
+			ChatSize:         2,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  0,
+
+			ExpectedMessage: `**Sender** messaged you in an [MS Teams chat: Topic](http://teams.microsoft.com/chat/1):
+> Hello!`,
+		},
+		{
+			Description: "chat message, one attachment, has topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "Topic",
+			ChatSize:         2,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  1,
+
+			ExpectedMessage: `**Sender** messaged you in an [MS Teams chat: Topic](http://teams.microsoft.com/chat/1):
+> Hello!
+
+*This message was originally sent with one attachment.*`,
+		},
+		{
+			Description: "chat message, more than one attachment, has topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "Topic",
+			ChatSize:         2,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  2,
+
+			ExpectedMessage: `**Sender** messaged you in an [MS Teams chat: Topic](http://teams.microsoft.com/chat/1):
+> Hello!
+
+*This message was originally sent with 2 attachments.*`,
+		},
+		{
+			Description: "group chat message, no attachments, no topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "",
+			ChatSize:         3,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  0,
+
+			ExpectedMessage: `**Sender** messaged you and 1 other user in an [MS Teams group chat](http://teams.microsoft.com/chat/1):
+> Hello!`,
+		},
+		{
+			Description: "group chat message, one attachment, no topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "",
+			ChatSize:         3,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  1,
+
+			ExpectedMessage: `**Sender** messaged you and 1 other user in an [MS Teams group chat](http://teams.microsoft.com/chat/1):
+> Hello!
+
+*This message was originally sent with one attachment.*`,
+		},
+		{
+			Description: "group chat message, more than one attachment, no topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "",
+			ChatSize:         3,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  2,
+
+			ExpectedMessage: `**Sender** messaged you and 1 other user in an [MS Teams group chat](http://teams.microsoft.com/chat/1):
+> Hello!
+
+*This message was originally sent with 2 attachments.*`,
+		},
+		{
+			Description: "group chat message, no attachments, has topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "Topic",
+			ChatSize:         3,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  0,
+
+			ExpectedMessage: `**Sender** messaged you and 1 other user in an [MS Teams group chat: Topic](http://teams.microsoft.com/chat/1):
+> Hello!`,
+		},
+		{
+			Description: "group chat message, one attachment, has topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "Topic",
+			ChatSize:         3,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  1,
+
+			ExpectedMessage: `**Sender** messaged you and 1 other user in an [MS Teams group chat: Topic](http://teams.microsoft.com/chat/1):
+> Hello!
+
+*This message was originally sent with one attachment.*`,
+		},
+		{
+			Description: "group chat message, more than one attachment, has topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "Topic",
+			ChatSize:         3,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  2,
+
+			ExpectedMessage: `**Sender** messaged you and 1 other user in an [MS Teams group chat: Topic](http://teams.microsoft.com/chat/1):
+> Hello!
+
+*This message was originally sent with 2 attachments.*`,
+		},
+		{
+			Description: "group chat message with 5 users, no attachments, no topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "",
+			ChatSize:         5,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  0,
+
+			ExpectedMessage: `**Sender** messaged you and 3 other users in an [MS Teams group chat](http://teams.microsoft.com/chat/1):
+> Hello!`,
+		},
+		{
+			Description: "group chat message with 5 users, one attachment, no topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "",
+			ChatSize:         5,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  1,
+
+			ExpectedMessage: `**Sender** messaged you and 3 other users in an [MS Teams group chat](http://teams.microsoft.com/chat/1):
+> Hello!
+
+*This message was originally sent with one attachment.*`,
+		},
+		{
+			Description: "group chat message with 5 users, more than one attachment, no topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "",
+			ChatSize:         5,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  2,
+
+			ExpectedMessage: `**Sender** messaged you and 3 other users in an [MS Teams group chat](http://teams.microsoft.com/chat/1):
+> Hello!
+
+*This message was originally sent with 2 attachments.*`,
+		},
+		{
+			Description: "group chat message with 5 users, no attachments, has topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "Topic",
+			ChatSize:         5,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  0,
+
+			ExpectedMessage: `**Sender** messaged you and 3 other users in an [MS Teams group chat: Topic](http://teams.microsoft.com/chat/1):
+> Hello!`,
+		},
+		{
+			Description: "group chat message with 5 users, one attachment, has topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "Topic",
+			ChatSize:         5,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  1,
+
+			ExpectedMessage: `**Sender** messaged you and 3 other users in an [MS Teams group chat: Topic](http://teams.microsoft.com/chat/1):
+> Hello!
+
+*This message was originally sent with one attachment.*`,
+		},
+		{
+			Description: "group chat message with 5 users, more than one attachment, has topic",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "Topic",
+			ChatSize:         5,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message:          "Hello!",
+			AttachmentCount:  2,
+
+			ExpectedMessage: `**Sender** messaged you and 3 other users in an [MS Teams group chat: Topic](http://teams.microsoft.com/chat/1):
+> Hello!
+
+*This message was originally sent with 2 attachments.*`,
+		},
+		{
+			Description: "multiline, complex chat message",
+
+			ActorDisplayName: "Sender",
+			ChatTopic:        "",
+			ChatSize:         2,
+			ChatLink:         "http://teams.microsoft.com/chat/1",
+			Message: `Hello!
+I heard you say:
+> Welcome!
+
+| Column A | Column B |
+| --- | --- |
+| Value 1 | Value 2 |
+
+` + "```" + `sql
+SELECT * FROM Users
+` + "```" + `
+`,
+			AttachmentCount: 2,
+
+			ExpectedMessage: `**Sender** messaged you in an [MS Teams chat](http://teams.microsoft.com/chat/1):
+> Hello!
+> I heard you say:
+> > Welcome!
+>` + " " + `
+> | Column A | Column B |
+> | --- | --- |
+> | Value 1 | Value 2 |
+>` + " " + `
+> ` + "```" + `sql
+> SELECT * FROM Users
+> ` + "```" + `
+
+*This message was originally sent with 2 attachments.*`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			actualMessage := formatNotificationMessage(
+				tc.ActorDisplayName,
+				tc.ChatTopic,
+				tc.ChatSize,
+				tc.ChatLink,
+				tc.Message,
+				tc.AttachmentCount,
+			)
+			assert.Equal(t, tc.ExpectedMessage, actualMessage)
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
Avoid this:
![image](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/013b64cf-8866-4252-a4ba-4370f922f733)

By doing this instead:
![CleanShot 2024-06-05 at 16 26 19@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/da0446fc-bf1a-43a4-a827-d377596cd529)

We're planning on supporting attachments in notifications, so I didn't spend a ton of time explaining this now, but instead added unit test coverage for the formatting expectations.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-58483