### PR TITLE
MM-58480: set user_user_icon with from_webhook

### DIFF
--- a/server/bot_messages.go
+++ b/server/bot_messages.go
@@ -26,6 +26,7 @@ func (p *Plugin) botSendDirectPost(userID string, post *model.Post) error {
 	// Force posts from the bot to render the user profile icon each time instead of collapsing
 	// adjacent posts. This helps draw attention to each individual post.
 	post.AddProp("from_webhook", "true")
+	post.AddProp("use_user_icon", "true")
 
 	return p.apiClient.Post.CreatePost(post)
 }


### PR DESCRIPTION
#### Summary
Turns out that if you set `from_webhook` (which we do to avoid collapsing adjacent messages), you also need `user_user_icon`, otherwise if `Enable integrations to override profile picture icons` is /enabled/ (yes!), it reverts to the default webhook URL.

Basically, change this:

![CleanShot 2024-06-05 at 16 45 26@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/c9c06a0d-1e6c-45fb-847a-23eaba695e3c)

To: 
![CleanShot 2024-06-05 at 16 45 36@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/0e87b6f3-2ccd-4e83-b80a-8251dbae2fbd)

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-58480