### PR TITLE
MM-58580: show message on welcome bot dismiss

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -1075,6 +1075,8 @@ func (a *API) siteStats(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) enableNotifications(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("Mattermost-User-ID")
+
 	var actionHandler model.PostActionIntegrationRequest
 	if err := json.NewDecoder(r.Body).Decode(&actionHandler); err != nil {
 		a.p.API.LogWarn("Unable to decode the action handler", "error", err.Error())

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -1130,19 +1130,34 @@ func TestConnectionStatus(t *testing.T) {
 	})
 }
 
-func TestEnableNotifications(t *testing.T) {
+func TestNotificationsWelcomeMessage(t *testing.T) {
 	th := setupTestHelper(t)
-	apiURL := th.pluginURL(t, "/enable-notifications")
 	team := th.SetupTeam(t)
 
-	sendRequest := func(t *testing.T, user *model.User, req model.PostActionIntegrationRequest) *http.Response {
+	triggerWelcomeMessage := func(th *testHelper, t *testing.T, user1 *model.User) *model.Post {
+		// Arrange: Send the welcome message and retrieve it
+		err := th.p.SendWelcomeMessageWithNotificationAction(user1.Id)
+		require.NoError(t, err)
+
+		dc, err := th.p.apiClient.Channel.GetDirect(user1.Id, th.p.botUserID)
+		require.NoError(t, err)
+
+		posts, err := th.p.apiClient.Post.GetPostsSince(dc.Id, time.Now().Add(-1*time.Minute).UnixMilli())
+		require.NoError(t, err)
+		require.Len(t, posts.Order, 1)
+		post := posts.Posts[posts.Order[0]]
+
+		return post
+	}
+
+	sendRequest := func(t *testing.T, user *model.User, url string, req model.PostActionIntegrationRequest) *http.Response {
 		t.Helper()
 		client1 := th.SetupClient(t, user.Id)
 
 		body, err := json.Marshal(req)
 		require.NoError(t, err)
 
-		request, err := http.NewRequest(http.MethodPost, apiURL, bytes.NewReader(body))
+		request, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 		require.NoError(t, err)
 
 		request.Header.Set(model.HeaderAuth, client1.AuthType+" "+client1.AuthToken)
@@ -1156,22 +1171,43 @@ func TestEnableNotifications(t *testing.T) {
 		return response
 	}
 
-	t.Run("enable notifications", func(t *testing.T) {
+	t.Run("enable", func(t *testing.T) {
 		th.Reset(t)
 		user1 := th.SetupUser(t, team)
 
 		// Arrange: Send the welcome message and retrieve it
-		err := th.p.SendWelcomeMessageWithNotificationAction(user1.Id)
-		require.NoError(t, err)
-		dc, err := th.p.apiClient.Channel.GetDirect(user1.Id, th.p.botUserID)
-		require.NoError(t, err)
-		posts, err := th.p.apiClient.Post.GetPostsSince(dc.Id, time.Now().Add(-1*time.Minute).UnixMilli())
-		require.NoError(t, err)
-		require.Len(t, posts.Order, 1)
-		post := posts.Posts[posts.Order[0]]
+		post := triggerWelcomeMessage(th, t, user1)
 
 		// Act: make the request pretending the user clicked the button
-		response := sendRequest(t, user1, model.PostActionIntegrationRequest{
+		response := sendRequest(t, user1, th.pluginURL(t, "/enable-notifications"), model.PostActionIntegrationRequest{
+			UserId: user1.Id,
+			PostId: post.Id,
+		})
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+
+		// Assert: 1. we return an update for the post
+		var resp model.PostActionIntegrationResponse
+		err := json.NewDecoder(response.Body).Decode(&resp)
+		require.NoError(t, err)
+		assert.Len(t, resp.Update.Attachments(), 0)
+		assert.Equal(t, "You will now start receiving notifications from chats or group chats in Teams. To change this setting, open your user settings or run `/msteams notifications`", resp.Update.Message)
+
+		// Assert: 2. the notification preference is updated
+		assert.True(t, th.p.getNotificationPreference(user1.Id))
+	})
+
+	t.Run("dismiss, notifications previously disabled", func(t *testing.T) {
+		th.Reset(t)
+		user1 := th.SetupUser(t, team)
+
+		err := th.p.setNotificationPreference(user1.Id, false)
+		require.NoError(t, err)
+
+		// Arrange: Send the welcome message and retrieve it
+		post := triggerWelcomeMessage(th, t, user1)
+
+		// Act: make the request pretending the user clicked the button
+		response := sendRequest(t, user1, th.pluginURL(t, "/dismiss-notifications"), model.PostActionIntegrationRequest{
 			UserId: user1.Id,
 			PostId: post.Id,
 		})
@@ -1182,15 +1218,37 @@ func TestEnableNotifications(t *testing.T) {
 		err = json.NewDecoder(response.Body).Decode(&resp)
 		require.NoError(t, err)
 		assert.Len(t, resp.Update.Attachments(), 0)
-		assert.Equal(t, "You will now start receiving notifications from chats or group chats in Teams. To change this setting, open your user settings or run `/msteams notifications`", resp.Update.Message)
+		assert.Equal(t, "To change your notification settings, open your user settings or run `/msteams notifications`", resp.Update.Message)
 
-		// Assert: 2. the notification preference is updated
-		pref, appErr := th.p.API.GetPreferenceForUser(
-			user1.Id,
-			PreferenceCategoryPlugin,
-			storemodels.PreferenceNameNotification,
-		)
-		require.Nil(t, appErr)
-		assert.EqualValues(t, storemodels.PreferenceValueNotificationOn, pref.Value)
+		// Assert: 2. the notification preference is unchanged
+		assert.False(t, th.p.getNotificationPreference(user1.Id))
+	})
+
+	t.Run("dismiss, notifications previously enabled", func(t *testing.T) {
+		th.Reset(t)
+		user1 := th.SetupUser(t, team)
+
+		err := th.p.setNotificationPreference(user1.Id, true)
+		require.NoError(t, err)
+
+		// Arrange: Send the welcome message and retrieve it
+		post := triggerWelcomeMessage(th, t, user1)
+
+		// Act: make the request pretending the user clicked the button
+		response := sendRequest(t, user1, th.pluginURL(t, "/dismiss-notifications"), model.PostActionIntegrationRequest{
+			UserId: user1.Id,
+			PostId: post.Id,
+		})
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+
+		// Assert: 1. we return an update for the post
+		var resp model.PostActionIntegrationResponse
+		err = json.NewDecoder(response.Body).Decode(&resp)
+		require.NoError(t, err)
+		assert.Len(t, resp.Update.Attachments(), 0)
+		assert.Equal(t, "To change your notification settings, open your user settings or run `/msteams notifications`", resp.Update.Message)
+
+		// Assert: 2. the notification preference is unchanged
+		assert.True(t, th.p.getNotificationPreference(user1.Id))
 	})
 }

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -1196,7 +1196,7 @@ func TestNotificationsWelcomeMessage(t *testing.T) {
 		assert.True(t, th.p.getNotificationPreference(user1.Id))
 	})
 
-	t.Run("dismiss, notifications previously disabled", func(t *testing.T) {
+	t.Run("disable, notifications previously disabled", func(t *testing.T) {
 		th.Reset(t)
 		user1 := th.SetupUser(t, team)
 
@@ -1207,7 +1207,7 @@ func TestNotificationsWelcomeMessage(t *testing.T) {
 		post := triggerWelcomeMessage(th, t, user1)
 
 		// Act: make the request pretending the user clicked the button
-		response := sendRequest(t, user1, th.pluginURL(t, "/dismiss-notifications"), model.PostActionIntegrationRequest{
+		response := sendRequest(t, user1, th.pluginURL(t, "/disable-notifications"), model.PostActionIntegrationRequest{
 			UserId: user1.Id,
 			PostId: post.Id,
 		})
@@ -1218,13 +1218,13 @@ func TestNotificationsWelcomeMessage(t *testing.T) {
 		err = json.NewDecoder(response.Body).Decode(&resp)
 		require.NoError(t, err)
 		assert.Len(t, resp.Update.Attachments(), 0)
-		assert.Equal(t, "To change your notification settings, open your user settings or run `/msteams notifications`", resp.Update.Message)
+		assert.Equal(t, "You will not receive notifications from chats or group chats in Teams. To change this setting, open your user settings or run `/msteams notifications`", resp.Update.Message)
 
-		// Assert: 2. the notification preference is unchanged
+		// Assert: 2. the notification preference is disabled
 		assert.False(t, th.p.getNotificationPreference(user1.Id))
 	})
 
-	t.Run("dismiss, notifications previously enabled", func(t *testing.T) {
+	t.Run("disable, notifications previously enabled", func(t *testing.T) {
 		th.Reset(t)
 		user1 := th.SetupUser(t, team)
 
@@ -1235,7 +1235,7 @@ func TestNotificationsWelcomeMessage(t *testing.T) {
 		post := triggerWelcomeMessage(th, t, user1)
 
 		// Act: make the request pretending the user clicked the button
-		response := sendRequest(t, user1, th.pluginURL(t, "/dismiss-notifications"), model.PostActionIntegrationRequest{
+		response := sendRequest(t, user1, th.pluginURL(t, "/disable-notifications"), model.PostActionIntegrationRequest{
 			UserId: user1.Id,
 			PostId: post.Id,
 		})
@@ -1246,9 +1246,9 @@ func TestNotificationsWelcomeMessage(t *testing.T) {
 		err = json.NewDecoder(response.Body).Decode(&resp)
 		require.NoError(t, err)
 		assert.Len(t, resp.Update.Attachments(), 0)
-		assert.Equal(t, "To change your notification settings, open your user settings or run `/msteams notifications`", resp.Update.Message)
+		assert.Equal(t, "You will not receive notifications from chats or group chats in Teams. To change this setting, open your user settings or run `/msteams notifications`", resp.Update.Message)
 
-		// Assert: 2. the notification preference is unchanged
-		assert.True(t, th.p.getNotificationPreference(user1.Id))
+		// Assert: 2. the notification preference is disabled
+		assert.False(t, th.p.getNotificationPreference(user1.Id))
 	})
 }

--- a/server/bot_messages.go
+++ b/server/bot_messages.go
@@ -122,9 +122,9 @@ func (p *Plugin) makeWelcomeMessageWithNotificationActionPost() *model.Post {
 						},
 						{
 							Integration: &model.PostActionIntegration{
-								URL: fmt.Sprintf("%s/dismiss-notifications", p.GetRelativeURL()),
+								URL: fmt.Sprintf("%s/disable-notifications", p.GetRelativeURL()),
 							},
-							Name:  "Dismiss",
+							Name:  "Disable",
 							Style: "default",
 							Type:  model.PostActionTypeButton,
 						},

--- a/server/bot_messages_test.go
+++ b/server/bot_messages_test.go
@@ -47,6 +47,6 @@ func TestSendWelcomeMessageWithNotificationAction(t *testing.T) {
 	require.EqualValues(t, "Enable Notifications", post.Attachments()[0].Actions[0].Name)
 	require.False(t, post.Attachments()[0].Actions[0].Disabled)
 	require.EqualValues(t, model.PostActionTypeButton, post.Attachments()[0].Actions[1].Type)
-	require.EqualValues(t, "Dismiss", post.Attachments()[0].Actions[1].Name)
+	require.EqualValues(t, "Disable", post.Attachments()[0].Actions[1].Name)
 	require.False(t, post.Attachments()[0].Actions[1].Disabled)
 }

--- a/server/preferences.go
+++ b/server/preferences.go
@@ -37,10 +37,17 @@ func (p *Plugin) setNotificationPreference(userID string, enable bool) error {
 }
 
 func (p *Plugin) updatePreferenceForUser(userID string, name string, value string) *model.AppError {
-	return p.API.UpdatePreferencesForUser(userID, []model.Preference{{
+	appErr := p.API.UpdatePreferencesForUser(userID, []model.Preference{{
 		UserId:   userID,
 		Category: PreferenceCategoryPlugin,
 		Name:     name,
 		Value:    value,
 	}})
+	if appErr != nil {
+		return appErr
+	}
+
+	p.apiClient.Log.Info("User changed preference", "user_id", userID, "category", PreferenceCategoryPlugin, "name", name, "value", value)
+
+	return nil
 }


### PR DESCRIPTION
#### Summary
When dismissing a welcome message from the MS Teams bot re: notifications, show a message explaining how to change those settings instead of just deleting it outright:

![CleanShot 2024-06-06 at 12 10 17@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/a4e7d737-cbd9-40fd-8b75-a285f4f0c76d)

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-58580