### PR TITLE
MM-58485: fix duplicate at-mentions

### DIFF
--- a/server/converters_test.go
+++ b/server/converters_test.go
@@ -173,7 +173,141 @@ func TestHandleMentions(t *testing.T) {
 					},
 				},
 			},
-			expectedMessage: "hello @mockMMUsername-1  from @mockMMUsername-2 ",
+			expectedMessage: "hello @mockMMUsername-1 from @mockMMUsername-2",
+		},
+		{
+			description: "multi-word user mentions",
+			setupAPI: func(api *plugintest.API) {
+				api.On("GetUser", "mockMMUserID-1").Return(&model.User{
+					Id:       "mockMMUserID-1",
+					Username: "miguel",
+				}, nil).Maybe()
+			},
+			setupStore: func(store *storemocks.Store) {
+				store.On("TeamsToMattermostUserID", "mockMSUserID-1").Return("mockMMUserID-1", nil).Maybe()
+			},
+			message: &clientmodels.Message{
+				Text: `hello <at id="0">Miguel</at>&nbsp;<at id="1">de</at>&nbsp;<at id="2">la</at>&nbsp;<at id="3">Cruz</at>`,
+				Mentions: []clientmodels.Mention{
+					{
+						ID:            0,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "Miguel",
+					},
+					{
+						ID:            1,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "de",
+					},
+					{
+						ID:            2,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "la",
+					},
+					{
+						ID:            3,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "Cruz",
+					},
+				},
+			},
+			expectedMessage: "hello @miguel",
+		},
+		{
+			description: "multi-word user mentions, unknown user",
+			setupAPI: func(api *plugintest.API) {
+				api.On("GetUser", "mockMMUserID-1").Return(&model.User{
+					Id:       "mockMMUserID-1",
+					Username: "miguel",
+				}, nil).Maybe()
+			},
+			setupStore: func(store *storemocks.Store) {
+				store.On("TeamsToMattermostUserID", "mockMSUserID-1").Return("", errors.New("unable to get mm user ID"))
+			},
+			message: &clientmodels.Message{
+				Text: `hello <at id="0">Miguel</at>&nbsp;<at id="1">de</at>&nbsp;<at id="2">la</at>&nbsp;<at id="3">Cruz</at>`,
+				Mentions: []clientmodels.Mention{
+					{
+						ID:            0,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "Miguel",
+					},
+					{
+						ID:            1,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "de",
+					},
+					{
+						ID:            2,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "la",
+					},
+					{
+						ID:            3,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "Cruz",
+					},
+				},
+			},
+			expectedMessage: `hello <at id="0">Miguel de la Cruz</at>`,
+		},
+		{
+			description: "multi-word user mentions, repeated",
+			setupAPI: func(api *plugintest.API) {
+				api.On("GetUser", "mockMMUserID-1").Return(&model.User{
+					Id:       "mockMMUserID-1",
+					Username: "miguel",
+				}, nil).Maybe()
+			},
+			setupStore: func(store *storemocks.Store) {
+				store.On("TeamsToMattermostUserID", "mockMSUserID-1").Return("mockMMUserID-1", nil).Maybe()
+			},
+			message: &clientmodels.Message{
+				Text: `hello <at id="0">Miguel</at>&nbsp;<at id="1">de</at>&nbsp;<at id="2">la</at>&nbsp;<at id="3">Cruz</at><at id="4">Miguel</at>&nbsp;<at id="5">de</at>&nbsp;<at id="6">la</at>&nbsp;<at id="7">Cruz</at>`,
+				Mentions: []clientmodels.Mention{
+					{
+						ID:            0,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "Miguel",
+					},
+					{
+						ID:            1,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "de",
+					},
+					{
+						ID:            2,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "la",
+					},
+					{
+						ID:            3,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "Cruz",
+					},
+					{
+						ID:            4,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "Miguel",
+					},
+					{
+						ID:            5,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "de",
+					},
+					{
+						ID:            6,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "la",
+					},
+					{
+						ID:            7,
+						UserID:        "mockMSUserID-1",
+						MentionedText: "Cruz",
+					},
+				},
+			},
+			expectedMessage: "hello @miguel@miguel",
 		},
 	} {
 		t.Run(testCase.description, func(t *testing.T) {


### PR DESCRIPTION
#### Summary
Teams sometimes translates an at-mention for a user like `Miguel De La Cruz` into four discrete mentions. Fortunately, these are combined in a way that's unique relative to adjacent mentions, even for the same user, so we can detect and patch these deterministically.

There was code that attempted to handle this, but it seemed to only deal with two mentions in a row. For reference, the payload from Teams looks something like this:
```json
"body": {
	"content": "<p>hello <at id=\"0\">Miguel</at>&nbsp;<at id=\"1\">de</at>&nbsp;<at id=\"2\">le</at>&nbsp;<at id=\"3\">Cruz</at><at id=\"4\">Miguel</at>&nbsp;<at id=\"5\">de</at>&nbsp;<at id=\"6\">le</at>&nbsp;<at id=\"7\">Cruz</at></p>"
	},
	"attachments": [],
	"mentions": [{
		"id": 0,
		"mentionText": "Miguel",
		"mentioned": {
			"user": {
				"id": "...",
				"displayName": "Miguel",
			}
		}
	}, {
		"id": 1,
		"mentionText": "de",
		"mentioned": {
			"user": {
				"id": "...",
				"displayName": "de",
			}
		}
	}, {
		"id": 2,
		"mentionText": "la",
		"mentioned": {
			"user": {
				"id": "...",
				"displayName": "la",
			}
		}
	}, {
		"id": 3,
		"mentionText": "Cruz",
		"mentioned": {
			"user": {
				"id": "...",
				"displayName": "Cruz",
			}
		}
	}
...
```

And ended up looking something like this:

![CleanShot 2024-06-06 at 17 16 55@2x](https://github.com/mattermost/mattermost-plugin-msteams/assets/1023171/a888d365-c7c6-497e-b5a6-73d4b8c6c7f9)

While we're in here, remove a redundant space after mentions.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-58484