### PR TITLE
MM-58702: don't assume JSON endpoint

### DIFF
--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -60,7 +60,12 @@ class ClientClass {
         const response = await fetch(url, Client4.getOptions(options));
 
         if (response.ok) {
-            return response.json();
+            // Not all endpoints return a JSON payload.
+            if (response.headers.get('content-type') === 'application/json') {
+                return response.json();
+            }
+
+            return response.text();
         }
 
         const text = await response.text();


### PR DESCRIPTION
#### Summary
Check the response header from the server before trying to interpret the response as JSON. Not all endpoints reply with JSON. And now those that should now do so explicitly.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-58702
