### PR TITLE
default notifications on

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -64,7 +64,7 @@
         "display_name": "Sync notifications",
         "type": "bool",
         "help_text": "Sync notifications of chat messages for any connected user that enables the feature.",
-        "default": false
+        "default": true
       },
       {
         "key": "maxSizeForCompleteDownload",


### PR DESCRIPTION
#### Summary
For new plugin installs, default the notifications experience on at the admin level (individual users still need to enable for themselves).

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-59509