### PR TITLE
MM-60005: dont notify if present

### DIFF
--- a/server/bot_messages.go
+++ b/server/bot_messages.go
@@ -77,7 +77,7 @@ func (p *Plugin) SendWelcomeMessageWithNotificationAction(userID string) error {
 func (p *Plugin) makeWelcomeMessageWithNotificationActionPost() *model.Post {
 	msg := []string{
 		"**Notifications from chats and group chats**",
-		"When you enable this feature, you'll be notified here in Mattermost by the MS Teams bot whenever you receive a message from a chat or group chat from Microsoft Teams!",
+		"When you enable this feature, you'll be notified here in Mattermost whenever you're away from Microsoft Teams and receive a message from a chat or group chat.",
 		fmt.Sprintf("![enable notifications picture](%s/static/enable_notifications.gif)", p.GetRelativeURL()),
 	}
 

--- a/server/credentials.go
+++ b/server/credentials.go
@@ -87,6 +87,13 @@ func getExpectedPermissions() []expectedPermission {
 				Type: "Role",
 			},
 		},
+		{
+			Name: "https://graph.microsoft.com/Presence.Read.All",
+			ResourceAccess: clientmodels.ResourceAccess{
+				ID:   "a70e0c2d-e793-494c-94c4-118fa0a67f42",
+				Type: "Role",
+			},
+		},
 	}
 }
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -143,6 +143,7 @@ func (ah *ActivityHandler) Handle(activity msteams.Activity) error {
 
 func (ah *ActivityHandler) HandleLifecycleEvent(event msteams.Activity) {
 	if event.LifecycleEvent != "reauthorizationRequired" {
+		ah.plugin.GetAPI().LogWarn("Ignoring unknown lifecycle event", "lifecycle_event", event.LifecycleEvent)
 		ah.plugin.GetMetrics().ObserveLifecycleEvent(event.LifecycleEvent, metrics.DiscardedReasonUnknownLifecycleEvent)
 		return
 	}
@@ -156,7 +157,7 @@ func (ah *ActivityHandler) HandleLifecycleEvent(event msteams.Activity) {
 		ah.plugin.GetAPI().LogWarn("Failed to lookup subscription, refreshing anyway", "subscription_id", event.SubscriptionID, "error", err.Error())
 	}
 
-	ah.plugin.GetAPI().LogWarn("Refreshing subscription", "subscription_id", event.SubscriptionID)
+	ah.plugin.GetAPI().LogInfo("Refreshing subscription", "subscription_id", event.SubscriptionID)
 	expiresOn, err := ah.plugin.GetClientForApp().RefreshSubscription(event.SubscriptionID)
 	if err != nil {
 		ah.plugin.GetAPI().LogWarn("Unable to refresh the subscription", "subscription_id", event.SubscriptionID, "error", err.Error())
@@ -164,7 +165,7 @@ func (ah *ActivityHandler) HandleLifecycleEvent(event msteams.Activity) {
 		return
 	}
 
-	ah.plugin.GetAPI().LogWarn("Refreshed subscription", "subscription_id", event.SubscriptionID, "expires_on", expiresOn.Format("2006-01-02 15:04:05.000 Z07:00"))
+	ah.plugin.GetAPI().LogInfo("Refreshed subscription", "subscription_id", event.SubscriptionID, "expires_on", expiresOn.Format("2006-01-02 15:04:05.000 Z07:00"))
 	ah.plugin.GetMetrics().ObserveSubscription(metrics.SubscriptionRefreshed)
 
 	if err = ah.plugin.GetStore().UpdateSubscriptionExpiresOn(event.SubscriptionID, *expiresOn); err != nil {

--- a/server/metrics/dashboards/dashboard.json
+++ b/server/metrics/dashboards/dashboard.json
@@ -727,6 +727,331 @@
         "x": 0,
         "y": 9
       },
+      "id": 78,
+      "panels": [],
+      "title": "Notifications",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 0,
+        "y": 10
+      },
+      "id": 71,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=~\"$namespace\",is_group_chat=\"false\",discarded_reason=\"\"}[5m])) by (action)",
+          "instant": false,
+          "legendFormat": "Chat",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=~\"$namespace\",is_group_chat=\"true\",discarded_reason=\"\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Group",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=\"$namespace\",discarded_reason=\"\"}[5m])) by (action)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Delivered Notifications (per second)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 10,
+        "y": 10
+      },
+      "id": 76,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=~\"$namespace\",discarded_reason!=\"\"}[5m])) by (discarded_reason)",
+          "instant": false,
+          "legendFormat": "{{discarded_reason}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Discarded Notifications (per second)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "Infinity": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "0%"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "yellow",
+                  "index": 0,
+                  "text": "0%"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 19,
+        "y": 10
+      },
+      "id": 77,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=~\"$namespace\",discarded_reason=\"\"}[15m])) / sum(rate(msteams_connect_events_notifications_total{namespace=~\"$namespace\"}[15m]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "% Delivered",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
       "id": 39,
       "panels": [],
       "title": "Application",
@@ -830,7 +1155,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 10
+        "y": 19
       },
       "id": 12,
       "options": {
@@ -1001,7 +1326,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 10
+        "y": 19
       },
       "id": 1,
       "options": {
@@ -1138,7 +1463,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 27
       },
       "id": 13,
       "options": {
@@ -1262,7 +1587,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 18
+        "y": 27
       },
       "id": 6,
       "options": {
@@ -1386,7 +1711,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 36
       },
       "id": 14,
       "options": {
@@ -1512,7 +1837,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 36
       },
       "id": 7,
       "options": {
@@ -1614,7 +1939,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 36
+        "y": 45
       },
       "id": 15,
       "options": {
@@ -1729,7 +2054,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 36
+        "y": 45
       },
       "id": 8,
       "options": {
@@ -1829,7 +2154,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 45
+        "y": 54
       },
       "id": 49,
       "options": {
@@ -1931,7 +2256,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 45
+        "y": 54
       },
       "id": 66,
       "options": {
@@ -2074,7 +2399,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 54
+        "y": 63
       },
       "id": 59,
       "options": {
@@ -2149,7 +2474,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 72
       },
       "id": 38,
       "panels": [],
@@ -2259,7 +2584,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 64
+        "y": 73
       },
       "id": 40,
       "options": {
@@ -2434,7 +2759,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 64
+        "y": 73
       },
       "id": 41,
       "options": {
@@ -2572,7 +2897,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 73
+        "y": 82
       },
       "id": 23,
       "options": {
@@ -2683,7 +3008,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 73
+        "y": 82
       },
       "id": 22,
       "options": {
@@ -2807,7 +3132,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 82
+        "y": 91
       },
       "id": 24,
       "options": {
@@ -2920,7 +3245,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 82
+        "y": 91
       },
       "id": 69,
       "options": {
@@ -3016,7 +3341,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 91
+        "y": 100
       },
       "id": 57,
       "options": {
@@ -3118,7 +3443,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 91
+        "y": 100
       },
       "id": 53,
       "options": {
@@ -3158,7 +3483,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 99
+        "y": 108
       },
       "id": 26,
       "panels": [],
@@ -3261,7 +3586,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 100
+        "y": 109
       },
       "id": 25,
       "options": {
@@ -3382,7 +3707,7 @@
         "h": 8,
         "w": 10,
         "x": 0,
-        "y": 108
+        "y": 117
       },
       "id": 27,
       "options": {
@@ -3479,7 +3804,7 @@
         "h": 8,
         "w": 9,
         "x": 10,
-        "y": 108
+        "y": 117
       },
       "id": 28,
       "options": {
@@ -3535,7 +3860,7 @@
             },
             {
               "options": {
-                "match": "nan",
+                "match": "null+nan",
                 "result": {
                   "color": "dark-yellow",
                   "index": 0,
@@ -3566,7 +3891,7 @@
         "h": 8,
         "w": 5,
         "x": 19,
-        "y": 108
+        "y": 117
       },
       "id": 42,
       "options": {
@@ -3668,7 +3993,7 @@
         "h": 8,
         "w": 10,
         "x": 0,
-        "y": 116
+        "y": 125
       },
       "id": 29,
       "options": {
@@ -3765,7 +4090,7 @@
         "h": 8,
         "w": 9,
         "x": 10,
-        "y": 116
+        "y": 125
       },
       "id": 30,
       "options": {
@@ -3821,7 +4146,7 @@
             },
             {
               "options": {
-                "match": "nan",
+                "match": "null+nan",
                 "result": {
                   "color": "yellow",
                   "index": 0,
@@ -3852,7 +4177,7 @@
         "h": 8,
         "w": 5,
         "x": 19,
-        "y": 116
+        "y": 125
       },
       "id": 43,
       "options": {
@@ -3954,7 +4279,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 124
+        "y": 133
       },
       "id": 37,
       "options": {
@@ -3988,135 +4313,12 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 132
-      },
-      "id": 71,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=~\"$namespace\",is_group_chat=\"false\"}[5m])) by (action)",
-          "instant": false,
-          "legendFormat": "Chat",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=~\"$namespace\",is_group_chat=\"true\"}[5m])) by (action)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Group",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=~\"$namespace\"}[5m])) by (action)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Total",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "Notifications (MSTeams -> Mattermost, per second)",
-      "type": "timeseries"
-    },
-    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 140
+        "y": 141
       },
       "id": 17,
       "panels": [],
@@ -4191,7 +4393,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 141
+        "y": 142
       },
       "id": 18,
       "options": {
@@ -4292,7 +4494,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 141
+        "y": 142
       },
       "id": 19,
       "options": {
@@ -4337,7 +4539,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 149
+        "y": 150
       },
       "id": 10,
       "panels": [],
@@ -4420,7 +4622,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 150
+        "y": 151
       },
       "id": 11,
       "options": {
@@ -4552,7 +4754,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 150
+        "y": 151
       },
       "id": 16,
       "options": {
@@ -4657,7 +4859,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 158
+        "y": 159
       },
       "id": 55,
       "options": {
@@ -4754,7 +4956,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 158
+        "y": 159
       },
       "id": 56,
       "options": {
@@ -4864,7 +5066,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 166
+        "y": 167
       },
       "id": 61,
       "options": {
@@ -4916,7 +5118,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 174
+        "y": 175
       },
       "id": 51,
       "panels": [],
@@ -4932,7 +5134,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 175
+        "y": 176
       },
       "id": 52,
       "options": {

--- a/server/metrics/dashboards/dashboard.json
+++ b/server/metrics/dashboards/dashboard.json
@@ -25,7 +25,7 @@
           "uid": "${datasource}"
         },
         "enable": true,
-        "expr": "msteams_connect_system_plugin_start_timestamp_seconds{namespace=\"$namespace\"} * 1000",
+        "expr": "msteams_connect_system_plugin_start_timestamp_seconds{namespace=~\"$namespace\"} * 1000",
         "iconColor": "green",
         "name": "Plugin Start",
         "target": {
@@ -44,7 +44,7 @@
           "uid": "${datasource}"
         },
         "enable": true,
-        "expr": "kube_pod_created{namespace=\"$namespace\"} * 1000",
+        "expr": "kube_pod_created{namespace=~\"$namespace\"} * 1000",
         "iconColor": "yellow",
         "name": "Pod created",
         "target": {
@@ -1409,7 +1409,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\",method=~\"$top_db_count\"}[5m])) by (method)",
+          "expr": "sum(increase(msteams_connect_db_store_time_seconds_count{namespace=~\"$namespace\",method=~\"$top_db_count\"}[5m])) by (method)",
           "instant": false,
           "legendFormat": "{{method}}",
           "range": true,
@@ -1641,7 +1641,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_db_store_time_seconds_sum{namespace=\"$namespace\",method=~\"$top_db_latency\"}[5m])) by (method) / sum(increase(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\",method=~\"$top_db_latency\"}[5m])) by (method)",
+          "expr": "sum(increase(msteams_connect_db_store_time_seconds_sum{namespace=~\"$namespace\",method=~\"$top_db_latency\"}[5m])) by (method) / sum(increase(msteams_connect_db_store_time_seconds_count{namespace=~\"$namespace\",method=~\"$top_db_latency\"}[5m])) by (method)",
           "instant": false,
           "legendFormat": "{{method}}",
           "range": true,
@@ -1852,7 +1852,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_system_plugin_goroutine_failures_total{namespace=\"$namespace\"}[5m])) by (instance) ",
+          "expr": "sum(rate(msteams_connect_system_plugin_goroutine_failures_total{namespace=~\"$namespace\"}[5m])) by (instance) ",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -3039,7 +3039,7 @@
             "uid": "P3497915E6DC419FB"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_msgraph_oauth_token_invalidated_total{namespace=\"$namespace\"}[5m]))",
+          "expr": "sum(increase(msteams_connect_msgraph_oauth_token_invalidated_total{namespace=~\"$namespace\"}[5m]))",
           "instant": false,
           "legendFormat": "Invalidated Tokens",
           "range": true,
@@ -3285,7 +3285,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_app_change_event_queue_length{namespace=\"$namespace\"}[5m])) by (instance)",
+          "expr": "sum(increase(msteams_connect_app_change_event_queue_length{namespace=~\"$namespace\"}[5m])) by (instance)",
           "hide": false,
           "instant": false,
           "legendFormat": "Length {{instance}}",
@@ -3298,7 +3298,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_events_change_event_queue_rejected_total{namespace=\"$namespace\"}[5m])) by (instance)",
+          "expr": "sum(increase(msteams_connect_events_change_event_queue_rejected_total{namespace=~\"$namespace\"}[5m])) by (instance)",
           "hide": false,
           "instant": false,
           "legendFormat": "Rejected {{instance}}",
@@ -3405,7 +3405,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_change_events_total{namespace=\"$namespace\",discarded_reason=\"\"}[5m])) by (change_type)",
+          "expr": "sum(rate(msteams_connect_events_change_events_total{namespace=~\"$namespace\",discarded_reason=\"\"}[5m])) by (change_type)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -3502,7 +3502,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_change_events_total{namespace=\"$namespace\",discarded_reason!=\"\"}[5m])) by (discarded_reason)",
+          "expr": "sum(rate(msteams_connect_events_change_events_total{namespace=~\"$namespace\",discarded_reason!=\"\"}[5m])) by (discarded_reason)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -3594,7 +3594,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_change_events_total{namespace=\"$namespace\",discarded_reason=\"\"}[15m])) / sum(rate(msteams_connect_events_change_events_total{namespace=\"$namespace\"}[15m]))",
+          "expr": "sum(rate(msteams_connect_events_change_events_total{namespace=~\"$namespace\",discarded_reason=\"\"}[15m])) / sum(rate(msteams_connect_events_change_events_total{namespace=~\"$namespace\"}[15m]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -3691,7 +3691,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_lifecycle_events_total{namespace=\"$namespace\"}[5m])) by (event_type)",
+          "expr": "sum(rate(msteams_connect_events_lifecycle_events_total{namespace=~\"$namespace\"}[5m])) by (event_type)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -3788,7 +3788,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_lifecycle_events_total{namespace=\"$namespace\",discarded_reason!=\"\"}[5m])) by (discarded_reason)",
+          "expr": "sum(rate(msteams_connect_events_lifecycle_events_total{namespace=~\"$namespace\",discarded_reason!=\"\"}[5m])) by (discarded_reason)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -3880,7 +3880,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_lifecycle_events_total{namespace=\"$namespace\",discarded_reason=\"\"}[15m])) / sum(rate(msteams_connect_events_lifecycle_events_total{namespace=\"$namespace\"}[15m]))",
+          "expr": "sum(rate(msteams_connect_events_lifecycle_events_total{namespace=~\"$namespace\",discarded_reason=\"\"}[15m])) / sum(rate(msteams_connect_events_lifecycle_events_total{namespace=~\"$namespace\"}[15m]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -3977,7 +3977,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_subscriptions_total{namespace=\"$namespace\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_subscriptions_total{namespace=~\"$namespace\"}[5m])) by (action)",
           "instant": false,
           "legendFormat": "{{action}}",
           "range": true,
@@ -4074,7 +4074,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=\"$namespace\",is_group_chat=\"false\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=~\"$namespace\",is_group_chat=\"false\"}[5m])) by (action)",
           "instant": false,
           "legendFormat": "Chat",
           "range": true,
@@ -4086,7 +4086,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=\"$namespace\",is_group_chat=\"true\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=~\"$namespace\",is_group_chat=\"true\"}[5m])) by (action)",
           "hide": false,
           "instant": false,
           "legendFormat": "Group",
@@ -4099,7 +4099,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=\"$namespace\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_notifications_total{namespace=~\"$namespace\"}[5m])) by (action)",
           "hide": false,
           "instant": false,
           "legendFormat": "Total",
@@ -4888,7 +4888,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(mattermost_db_master_connections_total{namespace=\"${namespace}\"})",
+          "expr": "sum(mattermost_db_master_connections_total{namespace=~\"${namespace}\"})",
           "interval": "",
           "legendFormat": "master",
           "range": true,
@@ -4900,7 +4900,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(mattermost_db_read_replica_connections_total{namespace=\"${namespace}\"})",
+          "expr": "sum(mattermost_db_read_replica_connections_total{namespace=~\"${namespace}\"})",
           "interval": "",
           "legendFormat": "replica",
           "range": true,
@@ -4952,7 +4952,7 @@
             "uid": "P4F55509B51A00EB7"
           },
           "editorMode": "code",
-          "expr": "{namespace=\"$namespace\"} | json | plugin_id=\"com.mattermost.msteams-sync\" | level=\"error\"",
+          "expr": "{namespace=~\"$namespace\"} | json | plugin_id=\"com.mattermost.msteams-sync\" | level=\"error\"",
           "queryType": "range",
           "refId": "A"
         },
@@ -4962,7 +4962,7 @@
             "uid": "PFB2D5CACEC34D62E"
           },
           "editorMode": "code",
-          "expr": "{namespace=\"$namespace\"} | json | plugin_id=\"com.mattermost.msteams-sync\" | level=\"error\"",
+          "expr": "{namespace=~\"$namespace\"} | json | plugin_id=\"com.mattermost.msteams-sync\" | level=\"error\"",
           "hide": false,
           "queryType": "range",
           "refId": "B"
@@ -5093,7 +5093,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+        "definition": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_seconds_count{namespace=~\"$namespace\"}[${__range_s}s])) by (method)))",
         "hide": 2,
         "includeAll": true,
         "multi": true,
@@ -5101,7 +5101,7 @@
         "options": [],
         "query": {
           "qryType": 3,
-          "query": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+          "query": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_seconds_count{namespace=~\"$namespace\"}[${__range_s}s])) by (method)))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -5124,7 +5124,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_seconds_sum{namespace=\"$namespace\"}[${__range_s}s])) by (method) / sum(increase(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+        "definition": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_seconds_sum{namespace=~\"$namespace\"}[${__range_s}s])) by (method) / sum(increase(msteams_connect_db_store_time_seconds_count{namespace=~\"$namespace\"}[${__range_s}s])) by (method)))",
         "hide": 2,
         "includeAll": true,
         "multi": true,
@@ -5132,7 +5132,7 @@
         "options": [],
         "query": {
           "qryType": 3,
-          "query": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_seconds_sum{namespace=\"$namespace\"}[${__range_s}s])) by (method) / sum(increase(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+          "query": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_seconds_sum{namespace=~\"$namespace\"}[${__range_s}s])) by (method) / sum(increase(msteams_connect_db_store_time_seconds_count{namespace=~\"$namespace\"}[${__range_s}s])) by (method)))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -5155,7 +5155,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+        "definition": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\"}[${__range_s}s])) by (method)))",
         "description": "",
         "hide": 2,
         "includeAll": true,
@@ -5164,7 +5164,7 @@
         "options": [],
         "query": {
           "qryType": 3,
-          "query": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+          "query": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\"}[${__range_s}s])) by (method)))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -5187,7 +5187,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+        "definition": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\"}[${__range_s}s])) by (method)))",
         "description": "",
         "hide": 2,
         "includeAll": true,
@@ -5196,7 +5196,7 @@
         "options": [],
         "query": {
           "qryType": 3,
-          "query": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+          "query": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\"}[${__range_s}s])) by (method)))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/server/metrics/dashboards/dashboard.json
+++ b/server/metrics/dashboards/dashboard.json
@@ -4882,7 +4882,7 @@
             "uid": "P27C405C01959D762"
           },
           "editorMode": "code",
-          "expr": "sum(msteams_connect_app_active_workers_total) by (worker)",
+          "expr": "sum(msteams_connect_app_active_workers_total{namespace=~\"$namespace\"}) by (worker)",
           "instant": false,
           "legendFormat": "{{worker}}",
           "range": true,

--- a/server/metrics/mocks/Metrics.go
+++ b/server/metrics/mocks/Metrics.go
@@ -70,11 +70,6 @@ func (_m *Metrics) ObserveActiveUsersReceiving(count int64) {
 	_m.Called(count)
 }
 
-// ObserveActiveUsersSending provides a mock function with given fields: count
-func (_m *Metrics) ObserveActiveUsersSending(count int64) {
-	_m.Called(count)
-}
-
 // ObserveChangeEvent provides a mock function with given fields: changeType, discardedReason
 func (_m *Metrics) ObserveChangeEvent(changeType string, discardedReason string) {
 	_m.Called(changeType, discardedReason)

--- a/server/msteams/client_disconnectionlayer/disconnectionlayer.go
+++ b/server/msteams/client_disconnectionlayer/disconnectionlayer.go
@@ -212,6 +212,17 @@ func (c *ClientDisconnectionLayer) GetMyID() (string, error) {
 	return result, err
 }
 
+func (c *ClientDisconnectionLayer) GetPresencesForUsers(userIDs []string) (map[string]*clientmodels.Presence, error) {
+	result, err := c.Client.GetPresencesForUsers(userIDs)
+	if err != nil {
+		var graphErr *msteams.GraphAPIError
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
+			c.onDisconnect(c.userID)
+		}
+	}
+	return result, err
+}
+
 func (c *ClientDisconnectionLayer) GetReply(teamID string, channelID string, messageID string, replyID string) (*clientmodels.Message, error) {
 	result, err := c.Client.GetReply(teamID, channelID, messageID, replyID)
 	if err != nil {

--- a/server/msteams/client_timerlayer/timerlayer.go
+++ b/server/msteams/client_timerlayer/timerlayer.go
@@ -412,6 +412,28 @@ func (c *ClientTimerLayer) GetMyID() (string, error) {
 	return result, err
 }
 
+func (c *ClientTimerLayer) GetPresencesForUsers(userIDs []string) (map[string]*clientmodels.Presence, error) {
+	statusCode := "2XX"
+	success := "true"
+	start := time.Now()
+
+	result, err := c.Client.GetPresencesForUsers(userIDs)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+
+	if err != nil {
+		success = "false"
+		statusCode = "0"
+		var apiErr *msteams.GraphAPIError
+		if errors.As(err, &apiErr) {
+			statusCode = strconv.Itoa(apiErr.StatusCode)
+		}
+	}
+
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetPresencesForUsers", success, statusCode, elapsed)
+	return result, err
+}
+
 func (c *ClientTimerLayer) GetReply(teamID string, channelID string, messageID string, replyID string) (*clientmodels.Message, error) {
 	statusCode := "2XX"
 	success := "true"

--- a/server/msteams/clientmodels/clientmodels.go
+++ b/server/msteams/clientmodels/clientmodels.go
@@ -114,3 +114,9 @@ type App struct {
 	Credentials       []Credential
 	RequiredResources []ResourceAccess
 }
+
+type Presence struct {
+	UserID       string
+	Availability string
+	Activity     string
+}

--- a/server/msteams/interface.go
+++ b/server/msteams/interface.go
@@ -57,4 +57,5 @@ type Client interface {
 	ListChannelMessages(teamID, channelID string, since time.Time) ([]*clientmodels.Message, error)
 	ListChatMessages(chatID string, since time.Time) ([]*clientmodels.Message, error)
 	GetApp(applicationID string) (*clientmodels.App, error)
+	GetPresencesForUsers(userIDs []string) (map[string]*clientmodels.Presence, error)
 }

--- a/server/msteams/mocks/Client.go
+++ b/server/msteams/mocks/Client.go
@@ -382,6 +382,29 @@ func (_m *Client) GetMyID() (string, error) {
 	return r0, r1
 }
 
+// GetPresencesForUsers provides a mock function with given fields: userIDs
+func (_m *Client) GetPresencesForUsers(userIDs []string) (map[string]*clientmodels.Presence, error) {
+	ret := _m.Called(userIDs)
+
+	var r0 map[string]*clientmodels.Presence
+	if rf, ok := ret.Get(0).(func([]string) map[string]*clientmodels.Presence); ok {
+		r0 = rf(userIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]*clientmodels.Presence)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = rf(userIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetReply provides a mock function with given fields: teamID, channelID, messageID, replyID
 func (_m *Client) GetReply(teamID string, channelID string, messageID string, replyID string) (*clientmodels.Message, error) {
 	ret := _m.Called(teamID, channelID, messageID, replyID)

--- a/server/notifications.go
+++ b/server/notifications.go
@@ -15,6 +15,22 @@ func (ah *ActivityHandler) handleCreatedActivityNotification(msg *clientmodels.M
 		return metrics.DiscardedReasonChannelNotificationsUnsupported
 	}
 
+	// Get the presence status for each chat member to decide if we should relay into Mattermost.
+	userIDs := make([]string, 0, len(chat.Members))
+	for _, member := range chat.Members {
+		// We won't notify senders about their own posts, so we don't need their presence.
+		if member.UserID == msg.UserID {
+			continue
+		}
+
+		userIDs = append(userIDs, member.UserID)
+	}
+
+	presences, err := ah.plugin.GetClientForApp().GetPresencesForUsers(userIDs)
+	if err != nil {
+		ah.plugin.GetAPI().LogWarn("Failed to fetch presence information for chat members", "chat_id", chat.ID, "message_id", msg.ID, "error", err)
+	}
+
 	botUserID := ah.plugin.GetBotUserID()
 
 	chatLink := fmt.Sprintf("https://teams.microsoft.com/l/message/%s/%s?tenantId=%s&context={\"contextType\":\"chat\"}", chat.ID, msg.ID, ah.plugin.GetTenantID())
@@ -33,6 +49,20 @@ func (ah *ActivityHandler) handleCreatedActivityNotification(msg *clientmodels.M
 		}
 
 		if !ah.plugin.getNotificationPreference(mattermostUserID) {
+			continue
+		}
+
+		// Don't notify users active in Teams.
+		if userPresenceIsActive(presences[member.UserID]) {
+			ah.plugin.GetAPI().LogInfo(
+				"Skipping notification for chat member present in Teams",
+				"user_id", mattermostUserID,
+				"teams_user_id", member.UserID,
+				"chat_id", chat.ID,
+				"message_id", msg.ID,
+				"activity", presences[member.UserID].Activity,
+				"availability", presences[member.UserID].Availability,
+			)
 			continue
 		}
 

--- a/server/notifications.go
+++ b/server/notifications.go
@@ -49,6 +49,13 @@ func (ah *ActivityHandler) handleCreatedActivityNotification(msg *clientmodels.M
 		}
 
 		if !ah.plugin.getNotificationPreference(mattermostUserID) {
+			ah.plugin.GetAPI().LogInfo(
+				"Skipping notification for chat member who disabled notifications",
+				"user_id", mattermostUserID,
+				"teams_user_id", member.UserID,
+				"chat_id", chat.ID,
+				"message_id", msg.ID,
+			)
 			continue
 		}
 

--- a/server/presence.go
+++ b/server/presence.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"github.com/mattermost/mattermost-plugin-msteams/server/msteams/clientmodels"
+)
+
+const (
+	PresenceActivityAvailable               = "Available"
+	PresenceActivityAway                    = "Away"
+	PresenceActivityBeRightBack             = "BeRightBack"
+	PresenceActivityBusy                    = "Busy"
+	PresenceActivityDoNotDisturb            = "DoNotDisturb"
+	PresenceActivityInACall                 = "InACall"
+	PresenceActivityInAConferenceCall       = "InAConferenceCall"
+	PresenceActivityInactive                = "Inactive"
+	PresenceActivityInAMeeting              = "InAMeeting"
+	PresenceActivityOffline                 = "Offline"
+	PresenceActivityOffWork                 = "OffWork"
+	PresenceActivityOutOfOffice             = "OutOfOffice"
+	PresenceActivityPresenceUnknown         = "PresenceUnknown"
+	PresenceActivityPresenting              = "Presenting"
+	PresenceActivityUrgentInterruptionsOnly = "UrgentInterruptionsOnly"
+
+	PresenceAvailabilityAvailable       = "Available"
+	PresenceAvailabilityAvailableIdle   = "AvailableIdle"
+	PresenceAvailabilityAway            = "Away"
+	PresenceAvailabilityBeRightBack     = "BeRightBack"
+	PresenceAvailabilityBusy            = "Busy"
+	PresenceAvailabilityBusyIdle        = "BusyIdle"
+	PresenceAvailabilityDoNotDisturb    = "DoNotDisturb"
+	PresenceAvailabilityOffline         = "Offline"
+	PresenceAvailabilityPresenceUnknown = "PresenceUnknown"
+)
+
+// userPresenceIsActive returns true if the user is considered online in Teams.
+func userPresenceIsActive(presence *clientmodels.Presence) bool {
+	// If we're missing presence, default to the user being inactive.
+	if presence == nil {
+		return false
+	}
+
+	// Explicitly handle known activity states for being inactive or away.
+	switch presence.Activity {
+	case PresenceActivityOffline, PresenceActivityInactive, PresenceAvailabilityAway:
+		return false
+	}
+
+	// Otherwise, assume the user is online.
+	return true
+}

--- a/server/store/mocks/Store.go
+++ b/server/store/mocks/Store.go
@@ -86,6 +86,27 @@ func (_m *Store) DeleteUserInvite(mmUserID string) error {
 	return r0
 }
 
+// GetActiveUsersCount provides a mock function with given fields: dur
+func (_m *Store) GetActiveUsersCount(dur time.Duration) (int64, error) {
+	ret := _m.Called(dur)
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(time.Duration) int64); ok {
+		r0 = rf(dur)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(time.Duration) error); ok {
+		r1 = rf(dur)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetChannelSubscription provides a mock function with given fields: subscriptionID
 func (_m *Store) GetChannelSubscription(subscriptionID string) (*storemodels.ChannelSubscription, error) {
 	ret := _m.Called(subscriptionID)
@@ -483,27 +504,6 @@ func (_m *Store) GetTokenForMattermostUser(userID string) (*oauth2.Token, error)
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(userID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetActiveUsersCount provides a mock function with given fields: dur
-func (_m *Store) GetActiveUsersCount(dur time.Duration) (int64, error) {
-	ret := _m.Called(dur)
-
-	var r0 int64
-	if rf, ok := ret.Get(0).(func(time.Duration) int64); ok {
-		r0 = rf(dur)
-	} else {
-		r0 = ret.Get(0).(int64)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(time.Duration) error); ok {
-		r1 = rf(dur)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/store/sqlstore/public_methods.go
+++ b/server/store/sqlstore/public_methods.go
@@ -42,6 +42,10 @@ func (s *SQLStore) DeleteUserInvite(mmUserID string) error {
 	return s.deleteUserInvite(s.db, mmUserID)
 }
 
+func (s *SQLStore) GetActiveUsersCount(dur time.Duration) (int64, error) {
+	return s.getActiveUsersCount(s.replica, dur)
+}
+
 func (s *SQLStore) GetChannelSubscription(subscriptionID string) (*storemodels.ChannelSubscription, error) {
 	return s.getChannelSubscription(s.replica, subscriptionID)
 }
@@ -112,10 +116,6 @@ func (s *SQLStore) GetTokenForMSTeamsUser(userID string) (*oauth2.Token, error) 
 
 func (s *SQLStore) GetTokenForMattermostUser(userID string) (*oauth2.Token, error) {
 	return s.getTokenForMattermostUser(s.replica, userID)
-}
-
-func (s *SQLStore) GetActiveUsersCount(dur time.Duration) (int64, error) {
-	return s.getActiveUsersCount(s.replica, dur)
 }
 
 func (s *SQLStore) GetUserConnectStatus(mmUserID string) (*storemodels.UserConnectStatus, error) {

--- a/server/store/timerlayer/timerlayer.go
+++ b/server/store/timerlayer/timerlayer.go
@@ -91,6 +91,20 @@ func (s *TimerLayer) DeleteUserInvite(mmUserID string) error {
 	return err
 }
 
+func (s *TimerLayer) GetActiveUsersCount(dur time.Duration) (int64, error) {
+	start := time.Now()
+
+	result, err := s.Store.GetActiveUsersCount(dur)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	success := "false"
+	if err == nil {
+		success = "true"
+	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetActiveUsersCount", success, elapsed)
+	return result, err
+}
+
 func (s *TimerLayer) GetChannelSubscription(subscriptionID string) (*storemodels.ChannelSubscription, error) {
 	start := time.Now()
 
@@ -340,20 +354,6 @@ func (s *TimerLayer) GetTokenForMattermostUser(userID string) (*oauth2.Token, er
 		success = "true"
 	}
 	s.metrics.ObserveStoreMethodDuration("Store.GetTokenForMattermostUser", success, elapsed)
-	return result, err
-}
-
-func (s *TimerLayer) GetActiveUsersCount(dur time.Duration) (int64, error) {
-	start := time.Now()
-
-	result, err := s.Store.GetActiveUsersCount(dur)
-
-	elapsed := float64(time.Since(start)) / float64(time.Second)
-	success := "false"
-	if err == nil {
-		success = "true"
-	}
-	s.metrics.ObserveStoreMethodDuration("Store.GetActiveUsersCount", success, elapsed)
 	return result, err
 }
 

--- a/server/subscriptions.go
+++ b/server/subscriptions.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-msteams/server/metrics"
 	"github.com/mattermost/mattermost-plugin-msteams/server/msteams/clientmodels"
 	"github.com/mattermost/mattermost-plugin-msteams/server/store/storemodels"
+	"github.com/pkg/errors"
 )
 
 func isExpired(expiresOn time.Time) bool {
@@ -139,8 +140,7 @@ func (m *Monitor) checkGlobalChatsSubscription(remoteSubscription *clientmodels.
 func (m *Monitor) getMSTeamsSubscriptionsMap() (msteamsSubscriptionsMap map[string]*clientmodels.Subscription, allChatsSubscription *clientmodels.Subscription, err error) {
 	msteamsSubscriptions, err := m.client.ListSubscriptions()
 	if err != nil {
-		m.api.LogError("Unable to list MS Teams subscriptions", "error", err.Error())
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "failed to list subscriptions")
 	}
 
 	msteamsSubscriptionsMap = make(map[string]*clientmodels.Subscription)


### PR DESCRIPTION
#### Summary
If a user gets a Teams notification in Mattermost and then hops over to Teams, they continue to get “spammed” by messages in the ensuing chat. Let’s detect user presence and only notify users if they aren’t available in Teams.

This also means that while a user is "Available" in Teams, they won't get notifications in Mattermost. By default, this will be the state for 5 minutes after a user was last active. Note that if a user has their mobile device connected, but in the background, it won't count against the user being seen by Mattermost as "Available" in Teams.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-60005