### PR TITLE
upgrade and placate golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ apply:
 ## Install go tools
 install-go-tools:
 	@echo Installing go tools
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 	$(GO) install gotest.tools/gotestsum@v1.7.0
 
 ## Runs eslint and golangci-lint


### PR DESCRIPTION
#### Summary
After a Go upgrade, I ran into issues with `golangci-lint`, which in tun required upgrading that tooling.

#### Ticket Link
None.