### PR TITLE
fix --disable-copyfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,11 @@ ifneq ($(HAS_WEBAPP),)
 	mkdir -p dist/$(PLUGIN_ID)/webapp
 	cp -r webapp/dist dist/$(PLUGIN_ID)/webapp/
 endif
+ifeq ($(shell uname),Darwin)
+	cd dist && tar --disable-copyfile -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
+else
 	cd dist && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
+endif
 
 	@echo plugin built at: dist/$(BUNDLE_NAME)
 


### PR DESCRIPTION
#### Summary
Fix an issue building on MacOS, copying this change from other plugins that have already updated.

#### Ticket Link
None