### PR TITLE
allow iframe redirect to configured SamlIdpURL

### DIFF
--- a/server/api_test.go
+++ b/server/api_test.go
@@ -1045,7 +1045,7 @@ func TestIFrameMattermostTab(t *testing.T) {
 	parsedURL, err := url.Parse(*siteURL)
 	require.NoError(t, err)
 	origin := parsedURL.Scheme + "://" + parsedURL.Host
-	expectedCSP := "default-src 'none'; frame-src 'self' " + origin + "; style-src 'unsafe-inline'"
+	expectedCSP := "default-src 'none'; frame-src 'self' " + origin
 	assert.Equal(t, expectedCSP, response.Header.Get("Content-Security-Policy"))
 	assert.Equal(t, "nosniff", response.Header.Get("X-Content-Type-Options"))
 	assert.Equal(t, "strict-origin-when-cross-origin", response.Header.Get("Referrer-Policy"))
@@ -1111,7 +1111,7 @@ func TestIFrameMattermostTabWithIdpURL(t *testing.T) {
 	require.NoError(t, err)
 	origin := parsedURL.Scheme + "://" + parsedURL.Host
 
-	expectedCSP := "default-src 'none'; frame-src 'self' " + origin + " https://idp.example.com" + "; style-src 'unsafe-inline'"
+	expectedCSP := "default-src 'none'; frame-src 'self' " + origin + " https://idp.example.com"
 	assert.Equal(t, expectedCSP, response.Header.Get("Content-Security-Policy"))
 	assert.Equal(t, "nosniff", response.Header.Get("X-Content-Type-Options"))
 	assert.Equal(t, "strict-origin-when-cross-origin", response.Header.Get("Referrer-Policy"))

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -1045,7 +1045,7 @@ func TestIFrameMattermostTab(t *testing.T) {
 	parsedURL, err := url.Parse(*siteURL)
 	require.NoError(t, err)
 	origin := parsedURL.Scheme + "://" + parsedURL.Host
-	expectedCSP := "default-src 'none'; frame-src " + origin + "; style-src 'unsafe-inline'"
+	expectedCSP := "default-src 'none'; frame-src 'self' " + origin + "; style-src 'unsafe-inline'"
 	assert.Equal(t, expectedCSP, response.Header.Get("Content-Security-Policy"))
 	assert.Equal(t, "nosniff", response.Header.Get("X-Content-Type-Options"))
 	assert.Equal(t, "strict-origin-when-cross-origin", response.Header.Get("Referrer-Policy"))
@@ -1062,6 +1062,71 @@ func TestIFrameMattermostTab(t *testing.T) {
 	require.NotNil(t, mmembedCookie, "MMEMBED cookie should be set")
 	assert.Equal(t, "1", mmembedCookie.Value)
 	// The cookie is not HttpOnly in the actual implementation
+	assert.Equal(t, "/", mmembedCookie.Path)
+	assert.True(t, mmembedCookie.Secure)
+	assert.Equal(t, http.SameSiteNoneMode, mmembedCookie.SameSite)
+}
+
+func TestIFrameMattermostTabWithIdpURL(t *testing.T) {
+	th := setupTestHelper(t)
+	apiURL := th.pluginURL(t, "/iframe/mattermostTab")
+	team := th.SetupTeam(t)
+	user := th.SetupUser(t, team)
+	client := th.SetupClient(t, user.Id)
+
+	th.Reset(t)
+
+	// Set IdpURL in config
+	config := th.p.API.GetConfig()
+	idpURL := "https://idp.example.com/saml"
+	config.SamlSettings.IdpURL = &idpURL
+	appErr := th.p.API.SaveConfig(config)
+	require.Nil(t, appErr)
+
+	request, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	require.NoError(t, err)
+
+	request.Header.Set(model.HeaderAuth, client.AuthType+" "+client.AuthToken)
+
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, response.Body.Close())
+	})
+
+	bodyBytes, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	bodyString := string(bodyBytes)
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Contains(t, bodyString, "<html")
+	assert.Contains(t, bodyString, "</html>")
+
+	// Verify iframe src matches site URL
+	siteURL := th.p.API.GetConfig().ServiceSettings.SiteURL
+	assert.Contains(t, bodyString, `src="`+*siteURL+`"`)
+
+	// Verify security headers are set correctly with IdP URL included
+	parsedURL, err := url.Parse(*siteURL)
+	require.NoError(t, err)
+	origin := parsedURL.Scheme + "://" + parsedURL.Host
+
+	expectedCSP := "default-src 'none'; frame-src 'self' " + origin + " https://idp.example.com" + "; style-src 'unsafe-inline'"
+	assert.Equal(t, expectedCSP, response.Header.Get("Content-Security-Policy"))
+	assert.Equal(t, "nosniff", response.Header.Get("X-Content-Type-Options"))
+	assert.Equal(t, "strict-origin-when-cross-origin", response.Header.Get("Referrer-Policy"))
+
+	// Verify MMEMBED cookie is set
+	cookies := response.Cookies()
+	var mmembedCookie *http.Cookie
+	for _, cookie := range cookies {
+		if cookie.Name == "MMEMBED" {
+			mmembedCookie = cookie
+			break
+		}
+	}
+	require.NotNil(t, mmembedCookie, "MMEMBED cookie should be set")
+	assert.Equal(t, "1", mmembedCookie.Value)
 	assert.Equal(t, "/", mmembedCookie.Path)
 	assert.True(t, mmembedCookie.Secure)
 	assert.Equal(t, http.SameSiteNoneMode, mmembedCookie.SameSite)

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -15,25 +15,42 @@ func (a *API) iFrame(w http.ResponseWriter, _ *http.Request) {
 	config := a.p.API.GetConfig()
 	siteURL := *config.ServiceSettings.SiteURL
 	if siteURL == "" {
-		a.p.API.LogError("SiteURL cannot be empty for MS Teams iFrame")
-		http.Error(w, "SiteURL is empty", http.StatusInternalServerError)
+		a.p.API.LogError("ServiceSettings.SiteURL cannot be empty for MS Teams iFrame")
+		http.Error(w, "ServiceSettings.SiteURL is empty", http.StatusInternalServerError)
 		return
 	}
 
 	parsedURL, err := url.Parse(siteURL)
 	if err != nil {
-		a.p.API.LogError("Invalid SiteURL for MS Teams iFrame", "error", err.Error())
-		http.Error(w, "Invalid SiteURL", http.StatusInternalServerError)
+		a.p.API.LogError("Invalid ServiceSettings.SiteURL for MS Teams iFrame", "error", err.Error())
+		http.Error(w, "Invalid ServiceSettings.SiteURL", http.StatusInternalServerError)
 		return
 	}
 
-	// Get the origin (scheme + host) for CSP
-	origin := parsedURL.Scheme + "://" + parsedURL.Host
+	// By default, only allow iframe to load content from Mattermost origin
+	frameSrc := []string{
+		"'self'",
+		parsedURL.Scheme + "://" + parsedURL.Host,
+	}
+
+	// If SAML is configured, allow loading the IdpURL to which a user must browse to complete sign on.
+	if config.SamlSettings.IdpURL != nil && *config.SamlSettings.IdpURL != "" {
+		parsedIDPURL, err := url.Parse(*config.SamlSettings.IdpURL)
+		if err != nil {
+			a.p.API.LogError("Invalid SamlSettings.IdpURL for MS Teams iFrame", "error", err.Error())
+			http.Error(w, "Invalid SamlSettings.IdpURL", http.StatusInternalServerError)
+			return
+		}
+
+		if parsedIDPURL != nil {
+			frameSrc = append(frameSrc, parsedIDPURL.Scheme+"://"+parsedIDPURL.Host)
+		}
+	}
 
 	// Set a minimal CSP for the wrapper page
 	cspDirectives := []string{
-		"default-src 'none'",        // Block all resources by default
-		"frame-src " + origin,       // Only allow iframe to load content from Mattermost origin
+		"default-src 'none'", // Block all resources by default
+		"frame-src " + strings.Join(frameSrc, " "),
 		"style-src 'unsafe-inline'", // Allow inline styles for the iframe positioning
 	}
 	w.Header().Set("Content-Security-Policy", strings.Join(cspDirectives, "; "))

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -51,7 +51,6 @@ func (a *API) iFrame(w http.ResponseWriter, _ *http.Request) {
 	cspDirectives := []string{
 		"default-src 'none'", // Block all resources by default
 		"frame-src " + strings.Join(frameSrc, " "),
-		"style-src 'unsafe-inline'", // Allow inline styles for the iframe positioning
 	}
 	w.Header().Set("Content-Security-Policy", strings.Join(cspDirectives, "; "))
 	w.Header().Set("X-Content-Type-Options", "nosniff")


### PR DESCRIPTION
#### Summary
To embed Mattermost and allow sign-on with a configured provider, we need to extend the `frame-src` directive accordingly. Similarly, add the `self` directive while we're in here.

#### Ticket Link
None