### PR TITLE
allow all frame-src for now

### DIFF
--- a/server/api_test.go
+++ b/server/api_test.go
@@ -1042,10 +1042,8 @@ func TestIFrameMattermostTab(t *testing.T) {
 	assert.Contains(t, bodyString, `src="`+*siteURL+`"`)
 
 	// Verify security headers are set correctly
-	parsedURL, err := url.Parse(*siteURL)
 	require.NoError(t, err)
-	origin := parsedURL.Scheme + "://" + parsedURL.Host
-	expectedCSP := "default-src 'none'; frame-src 'self' " + origin + "; style-src 'unsafe-inline'"
+	expectedCSP := "style-src 'unsafe-inline'"
 	assert.Equal(t, expectedCSP, response.Header.Get("Content-Security-Policy"))
 	assert.Equal(t, "nosniff", response.Header.Get("X-Content-Type-Options"))
 	assert.Equal(t, "strict-origin-when-cross-origin", response.Header.Get("Referrer-Policy"))
@@ -1107,11 +1105,9 @@ func TestIFrameMattermostTabWithIdpURL(t *testing.T) {
 	assert.Contains(t, bodyString, `src="`+*siteURL+`"`)
 
 	// Verify security headers are set correctly with IdP URL included
-	parsedURL, err := url.Parse(*siteURL)
 	require.NoError(t, err)
-	origin := parsedURL.Scheme + "://" + parsedURL.Host
 
-	expectedCSP := "default-src 'none'; frame-src 'self' " + origin + " https://idp.example.com" + "; style-src 'unsafe-inline'"
+	expectedCSP := "style-src 'unsafe-inline'"
 	assert.Equal(t, expectedCSP, response.Header.Get("Content-Security-Policy"))
 	assert.Equal(t, "nosniff", response.Header.Get("X-Content-Type-Options"))
 	assert.Equal(t, "strict-origin-when-cross-origin", response.Header.Get("Referrer-Policy"))

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -49,8 +49,6 @@ func (a *API) iFrame(w http.ResponseWriter, _ *http.Request) {
 
 	// Set a minimal CSP for the wrapper page
 	cspDirectives := []string{
-		"default-src 'none'", // Block all resources by default
-		"frame-src " + strings.Join(frameSrc, " "),
 		"style-src 'unsafe-inline'", // Allow inline styles for the iframe positioning
 	}
 	w.Header().Set("Content-Security-Policy", strings.Join(cspDirectives, "; "))


### PR DESCRIPTION
#### Summary
Remove the `default-src 'none'` directive and `frame-src` directives, as IDPs may redirect arbitrarily depending on their backend implementation.

#### Ticket Link
None