### PR TITLE
Fix scroll bars appearing on iFrame

### DIFF
--- a/server/iframe.go
+++ b/server/iframe.go
@@ -83,7 +83,7 @@ var iFrameHTML = `<!DOCTYPE html>
 </head>
 <body>
 	<iframe
-		style="position:absolute;top:0;left:0;width:100%;height:100%;border=none;"
+		style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;"
 		src="{{SITE_URL}}" title="Mattermost">
 	</iframe>
 </body>

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -83,7 +83,7 @@ var iFrameHTML = `<!DOCTYPE html>
 </head>
 <body>
 	<iframe
-		style="position:absolute;top:0px;width:100%;height:100vh;"
+		style="position:absolute;top:0;left:0;width:100%;height:100%;border=none;"
 		src="{{SITE_URL}}" title="Mattermost">
 	</iframe>
 </body>


### PR DESCRIPTION
#### Summary
In Chrome browsers the iFrame hosting MM web client was showing scroll bars due to lack of border setting.  This PR fixes the issue by explicitly setting a border (none) and setting a left position.

#### Ticket Link
NONE