### PR TITLE
feat: sso support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/JohannesKaufmann/html-to-markdown v1.6.0
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/enescakir/emoji v1.0.0
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/go-plugin v1.6.3
@@ -108,7 +109,6 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang-migrate/migrate/v4 v4.17.1 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/geo v0.0.0-20230421003525-6adc56603217 // indirect

--- a/server/api.go
+++ b/server/api.go
@@ -919,6 +919,14 @@ func (a *API) siteStats(w http.ResponseWriter, r *http.Request) {
 
 // userLogin is used to show a login page for the user to trigger the Microsoft Teams login flow
 func (a *API) userLogin(w http.ResponseWriter, r *http.Request) {
+	// If the user is already logged in, redirect to the home page
+	// TODO: Refactor the user properties setup to a function and call it from here if the user is already logged in
+	// just in case the user logs in from a tabApp in a browser.
+	if r.Header.Get("Mattermost-User-ID") != "" {
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return
+	}
+
 	html := `
 	<html>
 		<head>
@@ -950,7 +958,7 @@ func (a *API) userLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 // userLoginComplete is used to handle the callback from the Microsoft Teams login flow
-func (a *API) userLoginComplete(w http.ResponseWriter, r *http.Request) { // Get the token from the parammeters
+func (a *API) userLoginComplete(w http.ResponseWriter, r *http.Request) {
 	token := r.URL.Query().Get("token")
 	if token == "" {
 		a.p.API.LogError("No token provided")

--- a/server/api.go
+++ b/server/api.go
@@ -84,6 +84,7 @@ func NewAPI(p *Plugin, store store.Store) *API {
 
 	// iFrame support
 	router.HandleFunc("/iframe/mattermostTab", api.iFrame).Methods("GET")
+	router.HandleFunc("/users/setup", api.userSetup).Methods("GET")
 
 	return api
 }
@@ -909,4 +910,46 @@ func (a *API) siteStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	a.returnJSON(w, siteStats)
+}
+
+func (a *API) userSetup(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("Mattermost-User-ID")
+	if userID == "" {
+		http.Error(w, "Not authorized", http.StatusUnauthorized)
+		return
+	}
+
+	userId := r.URL.Query().Get("id")
+	if userId == "" {
+		http.Error(w, "Not authorized", http.StatusUnauthorized)
+		return
+	}
+
+	userPrincipalName := r.URL.Query().Get("user_principal_name")
+	if userPrincipalName == "" {
+		http.Error(w, "Not authorized", http.StatusUnauthorized)
+		return
+	}
+
+	a.p.API.LogInfo("Patching user", "user_id", userID)
+
+	user, appErr := a.p.API.GetUser(userID)
+	if appErr != nil {
+		a.p.API.LogError("Failed to get user", "error", appErr.Error())
+		http.Error(w, appErr.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	user.Props["com.mattermost.plugin-msteams-devsecops.user_principal_name"] = userPrincipalName
+	user.Props["com.mattermost.plugin-msteams-devsecops.user_id"] = userId
+
+	_, appErr = a.p.API.UpdateUser(user)
+	if appErr != nil {
+		a.p.API.LogError("Failed to patch user", "error", appErr.Error())
+		http.Error(w, appErr.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// w.WriteHeader(http.StatusOK)
+	http.Redirect(w, r, "/", http.StatusSeeOther)
 }

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -75,7 +75,7 @@ var iFrameHTML = `<!DOCTYPE html>
         microsoftTeams.authentication.getAuthToken()
         .then(function(token){
           // redirect to user complete page
-          iframe.src = "{{SITE_URL}}/plugins/{{PLUGIN_ID}}/users/login/complete?token=" + token;
+          iframe.src = event.data.href + "?token=" + token;
         })
         .catch(function (e) {
           console.error("Authentication failed:", e);


### PR DESCRIPTION
#### Summary

- Adds a route that users coming from SSO in an embedded experience get redirected to (see https://github.com/mattermost/mattermost/pull/30408)
- Adds JS to the iframe to handle the SSO logic
