### PR TITLE
feat: improve mention retrieval from posts, allows to disable notifications

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -102,6 +102,13 @@
         "default": false
       },
       {
+        "key": "enableUserActivityNotifications",
+        "display_name": "Enable User Activity Notifications",
+        "type": "bool",
+        "help_text": "Allows the plugin to send notification from Mattermost as activities in Microsoft Teams.",
+        "default": false
+      },
+      {
         "key": "connectedUsersWhitelist",
         "display_name": "New User Connections: Whitelist",
         "type": "custom",
@@ -114,13 +121,6 @@
         "type": "custom",
         "help_text": "",
         "default": ""
-      },
-      {
-        "key": "enableUserActivityNotifications",
-        "display_name": "Enable User Activity Notifications",
-        "type": "bool",
-        "help_text": "Allows the plugin to send notification from Mattermost as activities in Microsoft Teams.",
-        "default": false
       }
     ]
   }

--- a/plugin.json
+++ b/plugin.json
@@ -114,6 +114,13 @@
         "type": "custom",
         "help_text": "",
         "default": ""
+      },
+      {
+        "key": "enableUserActivityNotifications",
+        "display_name": "Enable User Activity Notifications",
+        "type": "bool",
+        "help_text": "Allows the plugin to send notification from Mattermost as activities in Microsoft Teams.",
+        "default": false
       }
     ]
   }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -35,6 +35,7 @@ type configuration struct {
 	ConnectedUsersRestricted        bool   `json:"connectedUsersRestricted"`
 	ConnectedUsersMaxPendingInvites int    `json:"connectedUsersMaxPendingInvites"`
 	DisableCheckCredentials         bool   `json:"internalDisableCheckCredentials"`
+	EnableUserActivityNotifications bool   `json:"enableUserActivityNotifications"`
 }
 
 func (c *configuration) ProcessConfiguration() {

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -84,9 +84,9 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(subEntityID, "post_") {
 			var team *model.Team
 			postID := strings.TrimPrefix(subEntityID, "post_")
-			post, err := a.p.API.GetPost(postID)
-			if err != nil {
-				logger.WithError(err).Error("Failed to get post to generate redirect path from subEntityId")
+			post, appErr := a.p.API.GetPost(postID)
+			if appErr != nil {
+				logger.WithError(appErr).Error("Failed to get post to generate redirect path from subEntityId")
 			}
 
 			channel, appErr := a.p.API.GetChannel(post.ChannelId)

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -282,7 +282,7 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 		return
 	}
 
-	parser := NewMentionParser(p.API, p.msteamsAppClient)
+	parser := NewNotificationsParser(p.API, p.msteamsAppClient)
 	if err := parser.ProcessPost(post); err != nil {
 		p.API.LogError("Failed to process mentions", "error", err.Error())
 		return

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -287,24 +287,28 @@ func (p *Plugin) getRedirectPathFromUser(logger logrus.FieldLogger, user *model.
 			post, appErr := p.API.GetPost(postID)
 			if appErr != nil {
 				logger.WithError(appErr).Error("Failed to get post to generate redirect path from subEntityId")
+				return "/"
 			}
 
 			channel, appErr := p.API.GetChannel(post.ChannelId)
 			if appErr != nil {
 				logger.WithError(appErr).Error("Failed to get channel to generate redirect path from subEntityId")
+				return "/"
 			}
 
 			if channel.TeamId == "" {
 				var teams []*model.Team
 				teams, appErr = p.API.GetTeamsForUser(user.Id)
-				if appErr != nil {
+				if appErr != nil || len(teams) == 0 {
 					logger.WithError(appErr).Error("Failed to get teams for user to generate redirect path from subEntityId")
+					return "/"
 				}
 				team = teams[0]
 			} else {
 				team, appErr = p.API.GetTeam(channel.TeamId)
 				if appErr != nil {
 					logger.WithError(appErr).Error("Failed to get team to generate redirect path from subEntityId")
+					return "/"
 				}
 			}
 

--- a/server/iframe.html
+++ b/server/iframe.html
@@ -14,14 +14,17 @@
     <iframe
         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;"
         title="Mattermost DevSecOps"
-        src="about:blank"
-        onload="notifyAppLoaded()">
+        src="about:blank">
     </iframe>
   <script>
     var iframe = document.querySelector('iframe');
 
     // Initialize the Microsoft Teams SDK
-    microsoftTeams.app.initialize(["{{SITE_URL}}"]);
+    microsoftTeams.app.initialize(["{{SITE_URL}}"]).then(() => {
+      microsoftTeams.app.notifySuccess();
+    }).catch((error) => {
+      console.error('Failed to initialize Microsoft Teams SDK:', error);
+    });
 
     // Define a map of tenant IDs to their corresponding domain roots
     const tenantMap = {
@@ -38,7 +41,6 @@
         tenantId = context.user.tenant.id;
       }
 
-      
       // If there's an explicit match in the tenant map, try to get auth token
       if (tenantMap[tenantId]) {
         const domainRoot = tenantMap[tenantId];
@@ -51,8 +53,21 @@
         // and send it to the iframe to redirect the user to what triggered the notification.
         if (context && context.page && context.page.subPageId) {
           params.set('sub_entity_id', context.page.subPageId);
+
+          // Since we received a sub_entity_id, redirect to the subEntityId page manually using the Microsoft Teams SDK.
+          // This is a workaround so we send the user to the tab application when opening the link from the 
+          // Microsoft Teams User Activity notifications page.
+          // Trying to navigate to the app within the app seems to be a no-op from the SDK, which is good for us.
+          microsoftTeams.pages.navigateToApp({
+            appId: context.app.appId.appIdAsString,
+            subPageId: context.page.subPageId
+          }).then(() => {
+            console.log("Successfully opened link, redirecting to the tab application.");
+          }).catch((error) => {
+            console.error('Failed to open link, fallback to using the iframe.', error);
+          });
         }
-  
+
         microsoftTeams.authentication.getAuthToken()
           .then((token) => {
             params.set('token', token);
@@ -68,10 +83,6 @@
         iframe.src = '{{SITE_URL}}';
       }
     });
-
-    function notifyAppLoaded() {
-      return microsoftTeams.app.notifySuccess();
-    }
   </script>
 </body>
 </html>

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -4,672 +4,319 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/url"
+	"regexp"
 	"strings"
-	"unicode"
-	"unicode/utf8"
 
+	"github.com/mattermost/mattermost-plugin-msteams/server/msteams"
 	"github.com/mattermost/mattermost/server/public/model"
-	"github.com/mattermost/mattermost/server/public/shared/markdown"
-	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/plugin"
 )
 
-const (
-	// Different types of mentions ordered by their priority from lowest to highest
-
-	// A placeholder that should never be used in practice
-	NoMention MentionType = iota
-
-	// The post is in a GM
-	GMMention
-
-	// The post is in a thread that the user has commented on
-	ThreadMention
-
-	// The post is a comment on a thread started by the user
-	CommentMention
-
-	// The post contains an at-channel, at-all, or at-here
-	ChannelMention
-
-	// The post is a DM
-	DMMention
-
-	// The post contains an at-mention for the user
-	KeywordMention
-
-	// The post contains a group mention for the user
-	GroupMention
-)
-
-type Notification struct {
+type Mention struct {
+	Trigger    string
 	Post       *model.Post
+	Channel    *model.Channel
 	PostAuthor *model.User
 	User       *model.User
-	Type       MentionType
+	Group      *model.Group
+	IsDM       bool // true if the mention is a DM
 }
 
-func NewNotification(post *model.Post, postAuthor *model.User, user *model.User, mentionType MentionType) *Notification {
-	return &Notification{
-		Post:       post,
-		PostAuthor: postAuthor,
-		User:       user,
-		Type:       mentionType,
+type MentionParser struct {
+	PAPI             plugin.API
+	Notifications    []*Mention
+	msteamsAppClient msteams.Client
+}
+
+func NewMentionParser(api plugin.API, msteamsAppClient msteams.Client) *MentionParser {
+	return &MentionParser{
+		PAPI:             api,
+		msteamsAppClient: msteamsAppClient,
 	}
 }
 
-type MentionType int
+func (p *MentionParser) ProcessPost(post *model.Post) error {
+	mentions := p.extractMentionsFromPost(post)
+	channel, err := p.PAPI.GetChannel(post.ChannelId)
+	if err != nil {
+		return err
+	}
 
-type MentionResults struct {
-	Team   *model.Team
-	Sender *model.User
+	for _, mention := range mentions {
+		m := &Mention{
+			Trigger: mention,
+			Post:    post,
+			Channel: channel,
+		}
 
-	// Mentions maps the ID of each user that was mentioned to how they were mentioned.
-	Mentions map[string]MentionType
+		switch mention {
+		case "@here":
+			fallthrough
+		case "@channel":
+			fallthrough
+		case "@all":
 
-	// GroupMentions maps the ID of each group that was mentioned to how it was mentioned.
-	GroupMentions map[string]MentionType
+		default:
+			user := p.isUserMention(strings.TrimPrefix(mention, "@"))
+			group := p.isGroupMention(strings.TrimPrefix(mention, "@"))
+			if user != nil {
+				m.User = user
+			} else if group != nil {
+				m.Group = group
+			}
+		}
 
-	// OtherPotentialMentions contains a list of strings that looked like mentions, but didn't have
-	// a corresponding keyword.
-	OtherPotentialMentions []string
+		p.Notifications = append(p.Notifications, m)
+	}
 
-	// HereMentioned is true if the message contained @here.
-	HereMentioned bool
+	if channel.Type == model.ChannelTypeDirect {
+		p.processDMsNotifications(channel, post)
+	}
 
-	// AllMentioned is true if the message contained @all.
-	AllMentioned bool
+	for _, notification := range p.Notifications {
+		p.PAPI.LogInfo("Processed mention", "notification", *notification)
+	}
 
-	// ChannelMentioned is true if the message contained @channel.
-	ChannelMentioned bool
+	return nil
 }
 
-func (m *MentionResults) isUserMentioned(userID string) bool {
-	if _, ok := m.Mentions[userID]; ok {
-		return true
-	}
-
-	if _, ok := m.GroupMentions[userID]; ok {
-		return true
-	}
-
-	return m.HereMentioned || m.AllMentioned || m.ChannelMentioned
-}
-
-func (m *MentionResults) addMention(userID string, mentionType MentionType) {
-	if m.Mentions == nil {
-		m.Mentions = make(map[string]MentionType)
-	}
-
-	if currentType, ok := m.Mentions[userID]; ok && currentType >= mentionType {
+func (p *MentionParser) processDMsNotifications(channel *model.Channel, post *model.Post) {
+	channelMembers, err := p.PAPI.GetChannelMembers(channel.Id, 0, 1000)
+	if err != nil {
+		p.PAPI.LogError("Failed to get channel members", "error", err.Error())
 		return
 	}
 
-	m.Mentions[userID] = mentionType
-}
+	for _, member := range channelMembers {
+		if member.UserId == post.UserId {
+			continue
+		}
 
-func (m *MentionResults) removeMention(userID string) {
-	delete(m.Mentions, userID)
-}
+		user, err := p.PAPI.GetUser(member.UserId)
+		if err != nil {
+			p.PAPI.LogError("Failed to get user", "error", err.Error())
+			continue
+		}
 
-func (m *MentionResults) addGroupMention(groupID string) {
-	if m.GroupMentions == nil {
-		m.GroupMentions = make(map[string]MentionType)
-	}
-
-	m.GroupMentions[groupID] = GroupMention
-}
-
-// Given a message and a map mapping mention keywords to the users who use them, returns a map of mentioned
-// users and a slice of potential mention users not in the channel and whether or not @here was mentioned.
-func getExplicitMentions(post *model.Post, keywords MentionKeywords) *MentionResults {
-	parser := makeStandardMentionParser(keywords)
-
-	buf := ""
-	mentionsEnabledFields := getMentionsEnabledFields(post)
-	for _, message := range mentionsEnabledFields {
-		// Parse the text as Markdown, combining adjacent Text nodes into a single string for processing
-		markdown.Inspect(message, func(node any) bool {
-			text, ok := node.(*markdown.Text)
-			if !ok {
-				// This node isn't a string so process any accumulated text in the buffer
-				if buf != "" {
-					parser.ProcessText(buf)
-				}
-
-				buf = ""
-				return true
-			}
-
-			// This node is a string, so add it to buf and continue onto the next node to see if it's more text
-			buf += text.Text
-			return false
+		p.Notifications = append(p.Notifications, &Mention{
+			Trigger: post.Message,
+			Post:    post,
+			Channel: channel,
+			User:    user,
 		})
 	}
+}
 
-	// Process any left over text
-	if buf != "" {
-		parser.ProcessText(buf)
+func (p *MentionParser) extractMentionsFromPost(post *model.Post) []string {
+	// Regular expression to find mentions of the form @username
+	mentionRegex := regexp.MustCompile(`@[a-zA-Z0-9._-]+`)
+	return mentionRegex.FindAllString(post.Message, -1)
+}
+
+func (p *MentionParser) isUserMention(mention string) *model.User {
+	user, err := p.PAPI.GetUserByUsername(mention)
+	if err != nil {
+		return nil
 	}
-
-	return parser.Results()
+	return user
 }
 
-// Have the compiler confirm *StandardMentionParser implements MentionParser
-var _ MentionParser = &StandardMentionParser{}
-
-type StandardMentionParser struct {
-	keywords MentionKeywords
-
-	results *MentionResults
-}
-
-func makeStandardMentionParser(keywords MentionKeywords) *StandardMentionParser {
-	return &StandardMentionParser{
-		keywords: keywords,
-
-		results: &MentionResults{},
+func (p *MentionParser) isGroupMention(mention string) *model.Group {
+	group, err := p.PAPI.GetGroupByName(mention)
+	if err != nil {
+		return nil
 	}
+	return group
 }
 
-// Processes text to filter mentioned users and other potential mentions
-func (p *StandardMentionParser) ProcessText(text string) {
-	systemMentions := map[string]bool{"@here": true, "@channel": true, "@all": true}
-
-	for _, word := range strings.FieldsFunc(text, func(c rune) bool {
-		// Split on any whitespace or punctuation that can't be part of an at mention or emoji pattern
-		return !(c == ':' || c == '.' || c == '-' || c == '_' || c == '@' || unicode.IsLetter(c) || unicode.IsNumber(c))
-	}) {
-		// skip word with format ':word:' with an assumption that it is an emoji format only
-		if word[0] == ':' && word[len(word)-1] == ':' {
-			continue
-		}
-
-		word = strings.TrimLeft(word, ":.-_")
-
-		if p.checkForMention(word) {
-			continue
-		}
-
-		foundWithoutSuffix := false
-		wordWithoutSuffix := word
-
-		for wordWithoutSuffix != "" && strings.LastIndexAny(wordWithoutSuffix, ".-:_") == (len(wordWithoutSuffix)-1) {
-			wordWithoutSuffix = wordWithoutSuffix[0 : len(wordWithoutSuffix)-1]
-
-			if p.checkForMention(wordWithoutSuffix) {
-				foundWithoutSuffix = true
-				break
-			}
-		}
-
-		if foundWithoutSuffix {
-			continue
-		}
-
-		if _, ok := systemMentions[word]; !ok && strings.HasPrefix(word, "@") {
-			// No need to bother about unicode as we are looking for ASCII characters.
-			last := word[len(word)-1]
-			switch last {
-			// If the word is possibly at the end of a sentence, remove that character.
-			case '.', '-', ':':
-				word = word[:len(word)-1]
-			}
-			p.results.OtherPotentialMentions = append(p.results.OtherPotentialMentions, word[1:])
-		} else if strings.ContainsAny(word, ".-:") {
-			// This word contains a character that may be the end of a sentence, so split further
-			splitWords := strings.FieldsFunc(word, func(c rune) bool {
-				return c == '.' || c == '-' || c == ':'
-			})
-
-			for _, splitWord := range splitWords {
-				if p.checkForMention(splitWord) {
-					continue
-				}
-				if _, ok := systemMentions[splitWord]; !ok && strings.HasPrefix(splitWord, "@") {
-					p.results.OtherPotentialMentions = append(p.results.OtherPotentialMentions, splitWord[1:])
-				}
-			}
-		}
-
-		if ids, match := isKeywordMultibyte(p.keywords, word); match {
-			p.addMentions(ids, KeywordMention)
+func (p *MentionParser) SendNotifications() error {
+	for _, mention := range p.Notifications {
+		if err := p.SendNotification(mention); err != nil {
+			p.PAPI.LogError("Failed to send notification", "error", err.Error())
 		}
 	}
+	return nil
 }
 
-func (p *StandardMentionParser) Results() *MentionResults {
-	return p.results
-}
+func (p *MentionParser) SendNotification(mention *Mention) error {
+	if mention.IsDM {
+		return p.sendDMNotification(mention)
+	}
 
-// checkForMention checks if there is a mention to a specific user or to the keywords here / channel / all
-func (p *StandardMentionParser) checkForMention(word string) bool {
-	var mentionType MentionType
+	if mention.User != nil {
+		return p.sendUserNotification(mention)
+	}
 
-	switch strings.ToLower(word) {
+	if mention.Group != nil {
+		return p.sendGroupNotification(mention)
+	}
+
+	switch mention.Trigger {
 	case "@here":
-		p.results.HereMentioned = true
-		mentionType = ChannelMention
+		return p.sendChannelNotification(mention, true)
 	case "@channel":
-		p.results.ChannelMentioned = true
-		mentionType = ChannelMention
+		fallthrough
 	case "@all":
-		p.results.AllMentioned = true
-		mentionType = ChannelMention
-	default:
-		mentionType = KeywordMention
+		return p.sendChannelNotification(mention, false)
 	}
-
-	if ids, match := p.keywords[strings.ToLower(word)]; match {
-		p.addMentions(ids, mentionType)
-		return true
-	}
-
-	// Case-sensitive check for first name
-	if ids, match := p.keywords[word]; match {
-		p.addMentions(ids, mentionType)
-		return true
-	}
-
-	return false
+	return nil
 }
 
-func (p *StandardMentionParser) addMentions(ids []MentionableID, mentionType MentionType) {
-	for _, id := range ids {
-		if userID, ok := id.AsUserID(); ok {
-			p.results.addMention(userID, mentionType)
-		} else if groupID, ok := id.AsGroupID(); ok {
-			p.results.addGroupMention(groupID)
-		}
-	}
+func (p *MentionParser) sendDMNotification(mention *Mention) error {
+	return p.sendUserActivityNotification(NewNotification(mention, mention.User))
 }
 
-// isKeywordMultibyte checks if a word containing a multibyte character contains a multibyte keyword
-func isKeywordMultibyte(keywords MentionKeywords, word string) ([]MentionableID, bool) {
-	ids := []MentionableID{}
-	match := false
-	var multibyteKeywords []string
-	for keyword := range keywords {
-		if len(keyword) != utf8.RuneCountInString(keyword) {
-			multibyteKeywords = append(multibyteKeywords, keyword)
-		}
+func (p *MentionParser) sendUserNotification(mention *Mention) error {
+	// Do not mention yourself
+	if mention.Post.UserId == mention.User.Id {
+		return nil
 	}
 
-	if len(word) != utf8.RuneCountInString(word) {
-		for _, key := range multibyteKeywords {
-			if strings.Contains(word, key) {
-				ids, match = keywords[key]
-			}
-		}
-	}
-	return ids, match
-}
-
-const (
-	mentionableUserPrefix  = "user:"
-	mentionableGroupPrefix = "group:"
-)
-
-// A MentionableID stores the ID of a single User/Group with information about which type of object it refers to.
-type MentionableID string
-
-func mentionableUserID(userID string) MentionableID {
-	return MentionableID(fmt.Sprint(mentionableUserPrefix, userID))
-}
-
-func mentionableGroupID(groupID string) MentionableID {
-	return MentionableID(fmt.Sprint(mentionableGroupPrefix, groupID))
-}
-
-func (id MentionableID) AsUserID() (userID string, ok bool) {
-	idString := string(id)
-	if !strings.HasPrefix(idString, mentionableUserPrefix) {
-		return "", false
-	}
-
-	return idString[len(mentionableUserPrefix):], true
-}
-
-func (id MentionableID) AsGroupID() (groupID string, ok bool) {
-	idString := string(id)
-	if !strings.HasPrefix(idString, mentionableGroupPrefix) {
-		return "", false
-	}
-
-	return idString[len(mentionableGroupPrefix):], true
-}
-
-// MentionKeywords is a collection of mention keywords and the IDs of the objects that have a given keyword.
-type MentionKeywords map[string][]MentionableID
-
-func (k MentionKeywords) AddUser(profile *model.User, channelNotifyProps map[string]string, status *model.Status, allowChannelMentions bool) MentionKeywords {
-	mentionableID := mentionableUserID(profile.Id)
-
-	userMention := "@" + strings.ToLower(profile.Username)
-	k[userMention] = append(k[userMention], mentionableID)
-
-	// Add all the user's mention keys
-	for _, mentionKey := range profile.GetMentionKeys() {
-		if mentionKey != "" {
-			// Note that these are made lower case so that we can do a case insensitive check for them
-			mentionKey = strings.ToLower(mentionKey)
-
-			k[mentionKey] = append(k[mentionKey], mentionableID)
-		}
-	}
-
-	// If turned on, add the user's case sensitive first name
-	if profile.NotifyProps[model.FirstNameNotifyProp] == "true" && profile.FirstName != "" {
-		k[profile.FirstName] = append(k[profile.FirstName], mentionableID)
-	}
-
-	// Add @channel and @all to k if user has them turned on and the server allows them
-	if allowChannelMentions {
-		// Ignore channel mentions if channel is muted and channel mention setting is default
-		ignoreChannelMentions := channelNotifyProps[model.IgnoreChannelMentionsNotifyProp] == model.IgnoreChannelMentionsOn || (channelNotifyProps[model.MarkUnreadNotifyProp] == model.UserNotifyMention && channelNotifyProps[model.IgnoreChannelMentionsNotifyProp] == model.IgnoreChannelMentionsDefault)
-
-		if profile.NotifyProps[model.ChannelMentionsNotifyProp] == "true" && !ignoreChannelMentions {
-			k["@channel"] = append(k["@channel"], mentionableID)
-			k["@all"] = append(k["@all"], mentionableID)
-
-			if status != nil && status.Status == model.StatusOnline {
-				k["@here"] = append(k["@here"], mentionableID)
-			}
-		}
-	}
-
-	return k
-}
-
-func (k MentionKeywords) AddUserKeyword(userID string, keyword string) MentionKeywords {
-	k[keyword] = append(k[keyword], mentionableUserID(userID))
-
-	return k
-}
-
-func (k MentionKeywords) AddGroup(group *model.Group) MentionKeywords {
-	if group.Name != nil {
-		keyword := "@" + *group.Name
-		k[keyword] = append(k[keyword], mentionableGroupID(group.Id))
-	}
-
-	return k
-}
-
-func (k MentionKeywords) AddGroupsMap(groups map[string]*model.Group) MentionKeywords {
-	for _, group := range groups {
-		k.AddGroup(group)
-	}
-
-	return k
-}
-
-type MentionParser interface {
-	ProcessText(text string)
-	Results() *MentionResults
-}
-
-// Given a post returns the values of the fields in which mentions are possible.
-// post.message, preText and text in the attachment are enabled.
-func getMentionsEnabledFields(post *model.Post) model.StringArray {
-	ret := []string{}
-
-	ret = append(ret, post.Message)
-	for _, attachment := range post.Attachments() {
-		if attachment.Pretext != "" {
-			ret = append(ret, attachment.Pretext)
-		}
-		if attachment.Text != "" {
-			ret = append(ret, attachment.Text)
-		}
-
-		for _, field := range attachment.Fields {
-			if valueString, ok := field.Value.(string); ok && valueString != "" {
-				ret = append(ret, valueString)
-			}
-		}
-	}
-	return ret
-}
-
-func (p *Plugin) IsCRTEnabledForUser(userID string) bool {
-	appCRT := *p.API.GetConfig().ServiceSettings.CollapsedThreads
-	if appCRT == model.CollapsedThreadsDisabled {
-		return false
-	}
-	if appCRT == model.CollapsedThreadsAlwaysOn {
-		return true
-	}
-	threadsEnabled := appCRT == model.CollapsedThreadsDefaultOn
-	// check if a participant has overridden collapsed threads settings
-	if preference, err := p.API.GetPreferenceForUser(userID, model.PreferenceCategoryDisplaySettings, model.PreferenceNameCollapsedThreadsEnabled); err == nil {
-		threadsEnabled = preference.Value == "on"
-	}
-	return threadsEnabled
-}
-
-// allowChannelMentions returns whether or not the channel mentions are allowed for the given post.
-func (p *Plugin) allowChannelMentions(post *model.Post, numProfiles int) bool {
-	if !p.API.HasPermissionToChannel(post.UserId, post.ChannelId, model.PermissionUseChannelMentions) {
-		return false
-	}
-
-	if post.Type == model.PostTypeHeaderChange || post.Type == model.PostTypePurposeChange {
-		return false
-	}
-
-	if int64(numProfiles) >= *p.API.GetConfig().TeamSettings.MaxNotificationsPerChannel {
-		return false
-	}
-
-	return true
-}
-
-func (p *Plugin) getMentionKeywordsInChannel(profiles map[string]*model.User, allowChannelMentions bool, channelMemberNotifyPropsMap map[string]model.StringMap, groups map[string]*model.Group) MentionKeywords {
-	keywords := make(MentionKeywords)
-
-	for _, profile := range profiles {
-		status, _ := p.API.GetUserStatus(profile.Id)
-		keywords.AddUser(
-			profile,
-			channelMemberNotifyPropsMap[profile.Id],
-			status,
-			allowChannelMentions,
-		)
-	}
-
-	keywords.AddGroupsMap(groups)
-
-	return keywords
-}
-
-func (p *Plugin) getExplicitMentionsAndKeywords(post *model.Post, channel *model.Channel, profileMap map[string]*model.User, groups map[string]*model.Group, channelMemberNotifyPropsMap map[string]model.StringMap, parentPostList *model.PostList) (*MentionResults, MentionKeywords) {
-	mentions := &MentionResults{}
-	var isAllowChannelMentions bool
-	var keywords MentionKeywords
-
-	if channel.Type == model.ChannelTypeDirect {
-		isWebhook := post.GetProp("from_webhook") == "true"
-
-		// A bot can post in a DM where it doesn't belong to.
-		// Therefore, we cannot "guess" who is the other user,
-		// so we add the mention to any user that is not the
-		// poster unless the post comes from a webhook.
-		user1, user2 := channel.GetBothUsersForDM()
-		if (post.UserId != user1) || isWebhook {
-			if _, ok := profileMap[user1]; ok {
-				mentions.addMention(user1, DMMention)
-			} else {
-				p.API.LogDebug("missing profile: DM user not in profiles", mlog.String("userId", user1), mlog.String("channelId", channel.Id))
-			}
-		}
-
-		if user2 != "" {
-			if (post.UserId != user2) || isWebhook {
-				if _, ok := profileMap[user2]; ok {
-					mentions.addMention(user2, DMMention)
-				} else {
-					p.API.LogDebug("missing profile: DM user not in profiles", mlog.String("userId", user2), mlog.String("channelId", channel.Id))
-				}
-			}
-		}
-	} else {
-		isAllowChannelMentions = p.allowChannelMentions(post, len(profileMap))
-		keywords = p.getMentionKeywordsInChannel(profileMap, isAllowChannelMentions, channelMemberNotifyPropsMap, groups)
-
-		mentions = getExplicitMentions(post, keywords)
-
-		// Add a GM mention to all members of a GM channel
-		if channel.Type == model.ChannelTypeGroup {
-			for id := range channelMemberNotifyPropsMap {
-				if _, ok := profileMap[id]; ok {
-					mentions.addMention(id, GMMention)
-				} else {
-					p.API.LogDebug("missing profile: GM user not in profiles", mlog.String("userId", id), mlog.String("channelId", channel.Id))
-				}
-			}
-		}
-
-		// Add an implicit mention when a user is added to a channel
-		// even if the user has set 'username mentions' to false in account settings.
-		if post.Type == model.PostTypeAddToChannel {
-			if addedUserId, ok := post.GetProp(model.PostPropsAddedUserId).(string); ok {
-				if _, ok := profileMap[addedUserId]; ok {
-					mentions.addMention(addedUserId, KeywordMention)
-				} else {
-					p.API.LogDebug("missing profile: user added to channel not in profiles", mlog.String("userId", addedUserId), mlog.String("channelId", channel.Id))
-				}
-			}
-		}
-
-		// Get users that have comment thread mentions enabled
-		if post.RootId != "" && parentPostList != nil {
-			for _, threadPost := range parentPostList.Posts {
-				profile := profileMap[threadPost.UserId]
-				if profile == nil {
-					// Not logging missing profile since this is relatively expected
-					continue
-				}
-
-				// If this is the root post and it was posted by an OAuth bot, don't notify the user
-				if threadPost.Id == parentPostList.Order[0] && threadPost.IsFromOAuthBot() {
-					continue
-				}
-				if p.IsCRTEnabledForUser(profile.Id) {
-					continue
-				}
-				if profile.NotifyProps[model.CommentsNotifyProp] == model.CommentsNotifyAny || (profile.NotifyProps[model.CommentsNotifyProp] == model.CommentsNotifyRoot && threadPost.Id == parentPostList.Order[0]) {
-					mentionType := ThreadMention
-					if threadPost.Id == parentPostList.Order[0] {
-						mentionType = CommentMention
-					}
-
-					mentions.addMention(threadPost.UserId, mentionType)
-				}
-			}
-		}
-
-		// Prevent the user from mentioning themselves
-		if post.GetProp("from_webhook") != "true" {
-			mentions.removeMention(post.UserId)
-		}
-	}
-
-	return mentions, keywords
-}
-
-func (p *Plugin) GetAllMentions(post *model.Post) (*MentionResults, error) {
-	// Get channel info
-	channel, err := p.API.GetChannel(post.ChannelId)
+	channelMembership, err := p.PAPI.GetChannelMember(mention.Post.ChannelId, mention.User.Id)
 	if err != nil {
-		p.API.LogError("Failed to get channel", "error", err.Error())
-		return nil, err
+		return err
+	}
+	if channelMembership == nil {
+		return nil
 	}
 
-	// Get user profiles for the channel
-	profiles, err := p.API.GetUsersInChannel(post.ChannelId, "username", 0, 1000)
+	notification := NewNotification(mention, mention.User)
+
+	return p.sendUserActivityNotification(notification)
+}
+
+func (p *MentionParser) sendGroupNotification(mention *Mention) error {
+	userGroup, err := p.PAPI.GetGroupMemberUsers(mention.Group.Id, 0, 1000)
 	if err != nil {
-		p.API.LogError("Failed to get users in channel", "error", err.Error())
-		return nil, err
+		return err
 	}
+	for _, user := range userGroup {
+		// Avoid sending notifications to the user who posted the message even if it's part of the group
+		if user.Id == mention.Post.UserId {
+			continue
+		}
 
-	// Convert profiles slice to map for easier lookup
-	profileMap := make(map[string]*model.User)
-	for _, profile := range profiles {
-		profileMap[profile.Id] = profile
-	}
-
-	// Get channel member notify properties
-	channelMemberNotifyPropsMap := make(map[string]model.StringMap)
-	members, err := p.API.GetChannelMembers(post.ChannelId, 0, 1000)
-	if err != nil {
-		p.API.LogError("Failed to get channel members", "error", err.Error())
-		return nil, err
-	}
-
-	for _, member := range members {
-		channelMemberNotifyPropsMap[member.UserId] = member.NotifyProps
-	}
-
-	// Get any parent posts if this is a reply
-	var parentPostList *model.PostList
-	if post.RootId != "" {
-		parentPostList, err = p.API.GetPostThread(post.RootId)
+		// only send notification if the user belongs to the channel the group was mentioned in
+		channelMembership, err := p.PAPI.GetChannelMember(mention.Post.ChannelId, user.Id)
 		if err != nil {
-			p.API.LogError("Failed to get parent post list", "error", err.Error())
-			return nil, err
+			return err
+		}
+		if channelMembership == nil {
+			continue
+		}
+
+		notification := NewNotification(mention, user)
+		if err := p.sendUserActivityNotification(notification); err != nil {
+			p.PAPI.LogError("Failed to send user activity notification", "error", err.Error())
 		}
 	}
 
-	// Get groups (for group mentions)
-	// TODO: Implement a method to get groups from the channel or the team
-	// We're using an empty map for groups for simplicity
-	groupsMap := make(map[string]*model.Group)
-
-	// Extract mentions using the existing method
-	mentions, _ := p.getExplicitMentionsAndKeywords(post, channel, profileMap, groupsMap, channelMemberNotifyPropsMap, parentPostList)
-
-	return mentions, nil
+	return nil
 }
 
-// formatMentionsForLog converts a map of mentions to a comma-separated string for logging
-func formatMentionsForLog(mentions map[string]MentionType) string {
-	if len(mentions) == 0 {
-		return "none"
+func (p *MentionParser) sendChannelNotification(mention *Mention, onlineOnly bool) error {
+	channelMembers, err := p.PAPI.GetChannelMembers(mention.Post.ChannelId, 0, 1000)
+	if err != nil {
+		return err
 	}
 
-	result := "["
-	first := true
-	for id, mentionType := range mentions {
-		if !first {
-			result += ", "
+	for _, member := range channelMembers {
+		if member.UserId == mention.Post.UserId {
+			continue
 		}
-		result += id + ":" + formatMentionType(mentionType)
-		first = false
+
+		// If online only, skip if the user is not online in mattermost.
+		// Used to match the behavior of @here in Mattermost.
+		if onlineOnly {
+			status, err := p.PAPI.GetUserStatus(member.UserId)
+			if err != nil {
+				return err
+			}
+			if status.Status != model.StatusOnline {
+				continue
+			}
+		}
+
+		user, err := p.PAPI.GetUser(member.UserId)
+		if err != nil {
+			return err
+		}
+
+		notification := NewNotification(mention, user)
+		if err := p.sendUserActivityNotification(notification); err != nil {
+			p.PAPI.LogError("Failed to send user activity notification", "error", err.Error())
+		}
 	}
-	return result + "]"
+
+	return nil
 }
 
-// formatMentionType converts a MentionType to a string representation
-func formatMentionType(mentionType MentionType) string {
-	switch mentionType {
-	case NoMention:
-		return "none"
-	case GMMention:
-		return "gm"
-	case ThreadMention:
-		return "thread"
-	case CommentMention:
-		return "comment"
-	case ChannelMention:
-		return "channel"
-	case DMMention:
-		return "dm"
-	case KeywordMention:
-		return "keyword"
-	case GroupMention:
-		return "group"
-	default:
-		return "unknown"
+func (p *MentionParser) sendUserActivityNotification(notification *Notification) error {
+	user, err := p.PAPI.GetUser(notification.User.Id)
+	if err != nil {
+		return err
+	}
+
+	appID, exists := user.GetProp(getUserPropKey("app_id"))
+	if !exists {
+		return nil
+	}
+
+	msteamsUserID, exists := user.GetProp(getUserPropKey("user_id"))
+	if !exists {
+		return nil
+	}
+
+	sender, err := p.PAPI.GetUser(notification.Mention.Post.UserId)
+	if err != nil {
+		p.PAPI.LogError("Failed to get sender", "error", err.Error())
+		return err
+	}
+
+	// Extract post message to use in notification
+	message := notification.Mention.Post.Message
+	if len(message) > 100 {
+		message = message[:97] + "..."
+	}
+
+	context := map[string]string{
+		"subEntityId": fmt.Sprintf("post_%s", notification.Mention.Post.Id),
+	}
+
+	jsonContext, jsonErr := json.Marshal(context)
+	if jsonErr != nil {
+		p.PAPI.LogError("Failed to marshal context", "error", jsonErr.Error())
+		return jsonErr
+	}
+
+	urlParams := url.Values{}
+	urlParams.Set("context", string(jsonContext))
+
+	if err := p.msteamsAppClient.SendUserActivity(msteamsUserID, "mattermost_mention_with_name", message, url.URL{
+		Scheme:   "https",
+		Host:     "teams.microsoft.com",
+		Path:     "/l/entity/" + appID + "/" + context["subEntityId"],
+		RawQuery: urlParams.Encode(),
+	}, map[string]string{
+		"post_author": sender.GetDisplayName(model.ShowNicknameFullName),
+	}); err != nil {
+		p.PAPI.LogError("Failed to send user activity notification", "error", err.Error())
+	}
+
+	return nil
+}
+
+type Notification struct {
+	Mention *Mention
+	User    *model.User
+}
+
+func NewNotification(mention *Mention, user *model.User) *Notification {
+	return &Notification{
+		Mention: mention,
+		User:    user,
 	}
 }

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -70,7 +70,7 @@ func (p *NotificationsParser) ProcessPost(post *model.Post) error {
 			}
 
 			if m.User == nil && m.Group == nil {
-				p.PAPI.LogError("Failed to find user or group for metnion", "mention", mention)
+				p.PAPI.LogDebug("Failed to find user or group for metnion", "mention", mention)
 				continue
 			}
 		}

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
 package main

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -142,7 +142,6 @@ func (p *NotificationsParser) SendNotification(notification *UserNotification) e
 	case "@here":
 		return p.sendChannelNotification(notification, true)
 	case "@channel":
-		fallthrough
 	case "@all":
 		return p.sendChannelNotification(notification, false)
 	}

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -60,11 +60,18 @@ func (p *NotificationsParser) ProcessPost(post *model.Post) error {
 
 		default:
 			user := p.isUserMention(strings.TrimPrefix(mention, "@"))
-			group := p.isGroupMention(strings.TrimPrefix(mention, "@"))
 			if user != nil {
 				m.User = user
-			} else if group != nil {
-				m.Group = group
+			} else {
+				group := p.isGroupMention(strings.TrimPrefix(mention, "@"))
+				if group != nil {
+					m.Group = group
+				}
+			}
+
+			if m.User == nil && m.Group == nil {
+				p.PAPI.LogError("Failed to find user or group for metnion", "mention", mention)
+				continue
 			}
 		}
 

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -87,7 +87,7 @@ func (p *NotificationsParser) ProcessPost(post *model.Post) error {
 	}
 
 	for _, notification := range p.Notifications {
-		p.PAPI.LogInfo("Processed mention", "notification", *notification)
+		p.PAPI.LogDebug("Processed mention", "notification", *notification)
 	}
 
 	return nil

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -141,8 +141,7 @@ func (p *NotificationsParser) SendNotification(notification *UserNotification) e
 	switch notification.Trigger {
 	case "@here":
 		return p.sendChannelNotification(notification, true)
-	case "@channel":
-	case "@all":
+	case "@all", "@channel":
 		return p.sendChannelNotification(notification, false)
 	}
 	return nil

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -1,0 +1,675 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/markdown"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+)
+
+const (
+	// Different types of mentions ordered by their priority from lowest to highest
+
+	// A placeholder that should never be used in practice
+	NoMention MentionType = iota
+
+	// The post is in a GM
+	GMMention
+
+	// The post is in a thread that the user has commented on
+	ThreadMention
+
+	// The post is a comment on a thread started by the user
+	CommentMention
+
+	// The post contains an at-channel, at-all, or at-here
+	ChannelMention
+
+	// The post is a DM
+	DMMention
+
+	// The post contains an at-mention for the user
+	KeywordMention
+
+	// The post contains a group mention for the user
+	GroupMention
+)
+
+type Notification struct {
+	Post       *model.Post
+	PostAuthor *model.User
+	User       *model.User
+	Type       MentionType
+}
+
+func NewNotification(post *model.Post, postAuthor *model.User, user *model.User, mentionType MentionType) *Notification {
+	return &Notification{
+		Post:       post,
+		PostAuthor: postAuthor,
+		User:       user,
+		Type:       mentionType,
+	}
+}
+
+type MentionType int
+
+type MentionResults struct {
+	Team   *model.Team
+	Sender *model.User
+
+	// Mentions maps the ID of each user that was mentioned to how they were mentioned.
+	Mentions map[string]MentionType
+
+	// GroupMentions maps the ID of each group that was mentioned to how it was mentioned.
+	GroupMentions map[string]MentionType
+
+	// OtherPotentialMentions contains a list of strings that looked like mentions, but didn't have
+	// a corresponding keyword.
+	OtherPotentialMentions []string
+
+	// HereMentioned is true if the message contained @here.
+	HereMentioned bool
+
+	// AllMentioned is true if the message contained @all.
+	AllMentioned bool
+
+	// ChannelMentioned is true if the message contained @channel.
+	ChannelMentioned bool
+}
+
+func (m *MentionResults) isUserMentioned(userID string) bool {
+	if _, ok := m.Mentions[userID]; ok {
+		return true
+	}
+
+	if _, ok := m.GroupMentions[userID]; ok {
+		return true
+	}
+
+	return m.HereMentioned || m.AllMentioned || m.ChannelMentioned
+}
+
+func (m *MentionResults) addMention(userID string, mentionType MentionType) {
+	if m.Mentions == nil {
+		m.Mentions = make(map[string]MentionType)
+	}
+
+	if currentType, ok := m.Mentions[userID]; ok && currentType >= mentionType {
+		return
+	}
+
+	m.Mentions[userID] = mentionType
+}
+
+func (m *MentionResults) removeMention(userID string) {
+	delete(m.Mentions, userID)
+}
+
+func (m *MentionResults) addGroupMention(groupID string) {
+	if m.GroupMentions == nil {
+		m.GroupMentions = make(map[string]MentionType)
+	}
+
+	m.GroupMentions[groupID] = GroupMention
+}
+
+// Given a message and a map mapping mention keywords to the users who use them, returns a map of mentioned
+// users and a slice of potential mention users not in the channel and whether or not @here was mentioned.
+func getExplicitMentions(post *model.Post, keywords MentionKeywords) *MentionResults {
+	parser := makeStandardMentionParser(keywords)
+
+	buf := ""
+	mentionsEnabledFields := getMentionsEnabledFields(post)
+	for _, message := range mentionsEnabledFields {
+		// Parse the text as Markdown, combining adjacent Text nodes into a single string for processing
+		markdown.Inspect(message, func(node any) bool {
+			text, ok := node.(*markdown.Text)
+			if !ok {
+				// This node isn't a string so process any accumulated text in the buffer
+				if buf != "" {
+					parser.ProcessText(buf)
+				}
+
+				buf = ""
+				return true
+			}
+
+			// This node is a string, so add it to buf and continue onto the next node to see if it's more text
+			buf += text.Text
+			return false
+		})
+	}
+
+	// Process any left over text
+	if buf != "" {
+		parser.ProcessText(buf)
+	}
+
+	return parser.Results()
+}
+
+// Have the compiler confirm *StandardMentionParser implements MentionParser
+var _ MentionParser = &StandardMentionParser{}
+
+type StandardMentionParser struct {
+	keywords MentionKeywords
+
+	results *MentionResults
+}
+
+func makeStandardMentionParser(keywords MentionKeywords) *StandardMentionParser {
+	return &StandardMentionParser{
+		keywords: keywords,
+
+		results: &MentionResults{},
+	}
+}
+
+// Processes text to filter mentioned users and other potential mentions
+func (p *StandardMentionParser) ProcessText(text string) {
+	systemMentions := map[string]bool{"@here": true, "@channel": true, "@all": true}
+
+	for _, word := range strings.FieldsFunc(text, func(c rune) bool {
+		// Split on any whitespace or punctuation that can't be part of an at mention or emoji pattern
+		return !(c == ':' || c == '.' || c == '-' || c == '_' || c == '@' || unicode.IsLetter(c) || unicode.IsNumber(c))
+	}) {
+		// skip word with format ':word:' with an assumption that it is an emoji format only
+		if word[0] == ':' && word[len(word)-1] == ':' {
+			continue
+		}
+
+		word = strings.TrimLeft(word, ":.-_")
+
+		if p.checkForMention(word) {
+			continue
+		}
+
+		foundWithoutSuffix := false
+		wordWithoutSuffix := word
+
+		for wordWithoutSuffix != "" && strings.LastIndexAny(wordWithoutSuffix, ".-:_") == (len(wordWithoutSuffix)-1) {
+			wordWithoutSuffix = wordWithoutSuffix[0 : len(wordWithoutSuffix)-1]
+
+			if p.checkForMention(wordWithoutSuffix) {
+				foundWithoutSuffix = true
+				break
+			}
+		}
+
+		if foundWithoutSuffix {
+			continue
+		}
+
+		if _, ok := systemMentions[word]; !ok && strings.HasPrefix(word, "@") {
+			// No need to bother about unicode as we are looking for ASCII characters.
+			last := word[len(word)-1]
+			switch last {
+			// If the word is possibly at the end of a sentence, remove that character.
+			case '.', '-', ':':
+				word = word[:len(word)-1]
+			}
+			p.results.OtherPotentialMentions = append(p.results.OtherPotentialMentions, word[1:])
+		} else if strings.ContainsAny(word, ".-:") {
+			// This word contains a character that may be the end of a sentence, so split further
+			splitWords := strings.FieldsFunc(word, func(c rune) bool {
+				return c == '.' || c == '-' || c == ':'
+			})
+
+			for _, splitWord := range splitWords {
+				if p.checkForMention(splitWord) {
+					continue
+				}
+				if _, ok := systemMentions[splitWord]; !ok && strings.HasPrefix(splitWord, "@") {
+					p.results.OtherPotentialMentions = append(p.results.OtherPotentialMentions, splitWord[1:])
+				}
+			}
+		}
+
+		if ids, match := isKeywordMultibyte(p.keywords, word); match {
+			p.addMentions(ids, KeywordMention)
+		}
+	}
+}
+
+func (p *StandardMentionParser) Results() *MentionResults {
+	return p.results
+}
+
+// checkForMention checks if there is a mention to a specific user or to the keywords here / channel / all
+func (p *StandardMentionParser) checkForMention(word string) bool {
+	var mentionType MentionType
+
+	switch strings.ToLower(word) {
+	case "@here":
+		p.results.HereMentioned = true
+		mentionType = ChannelMention
+	case "@channel":
+		p.results.ChannelMentioned = true
+		mentionType = ChannelMention
+	case "@all":
+		p.results.AllMentioned = true
+		mentionType = ChannelMention
+	default:
+		mentionType = KeywordMention
+	}
+
+	if ids, match := p.keywords[strings.ToLower(word)]; match {
+		p.addMentions(ids, mentionType)
+		return true
+	}
+
+	// Case-sensitive check for first name
+	if ids, match := p.keywords[word]; match {
+		p.addMentions(ids, mentionType)
+		return true
+	}
+
+	return false
+}
+
+func (p *StandardMentionParser) addMentions(ids []MentionableID, mentionType MentionType) {
+	for _, id := range ids {
+		if userID, ok := id.AsUserID(); ok {
+			p.results.addMention(userID, mentionType)
+		} else if groupID, ok := id.AsGroupID(); ok {
+			p.results.addGroupMention(groupID)
+		}
+	}
+}
+
+// isKeywordMultibyte checks if a word containing a multibyte character contains a multibyte keyword
+func isKeywordMultibyte(keywords MentionKeywords, word string) ([]MentionableID, bool) {
+	ids := []MentionableID{}
+	match := false
+	var multibyteKeywords []string
+	for keyword := range keywords {
+		if len(keyword) != utf8.RuneCountInString(keyword) {
+			multibyteKeywords = append(multibyteKeywords, keyword)
+		}
+	}
+
+	if len(word) != utf8.RuneCountInString(word) {
+		for _, key := range multibyteKeywords {
+			if strings.Contains(word, key) {
+				ids, match = keywords[key]
+			}
+		}
+	}
+	return ids, match
+}
+
+const (
+	mentionableUserPrefix  = "user:"
+	mentionableGroupPrefix = "group:"
+)
+
+// A MentionableID stores the ID of a single User/Group with information about which type of object it refers to.
+type MentionableID string
+
+func mentionableUserID(userID string) MentionableID {
+	return MentionableID(fmt.Sprint(mentionableUserPrefix, userID))
+}
+
+func mentionableGroupID(groupID string) MentionableID {
+	return MentionableID(fmt.Sprint(mentionableGroupPrefix, groupID))
+}
+
+func (id MentionableID) AsUserID() (userID string, ok bool) {
+	idString := string(id)
+	if !strings.HasPrefix(idString, mentionableUserPrefix) {
+		return "", false
+	}
+
+	return idString[len(mentionableUserPrefix):], true
+}
+
+func (id MentionableID) AsGroupID() (groupID string, ok bool) {
+	idString := string(id)
+	if !strings.HasPrefix(idString, mentionableGroupPrefix) {
+		return "", false
+	}
+
+	return idString[len(mentionableGroupPrefix):], true
+}
+
+// MentionKeywords is a collection of mention keywords and the IDs of the objects that have a given keyword.
+type MentionKeywords map[string][]MentionableID
+
+func (k MentionKeywords) AddUser(profile *model.User, channelNotifyProps map[string]string, status *model.Status, allowChannelMentions bool) MentionKeywords {
+	mentionableID := mentionableUserID(profile.Id)
+
+	userMention := "@" + strings.ToLower(profile.Username)
+	k[userMention] = append(k[userMention], mentionableID)
+
+	// Add all the user's mention keys
+	for _, mentionKey := range profile.GetMentionKeys() {
+		if mentionKey != "" {
+			// Note that these are made lower case so that we can do a case insensitive check for them
+			mentionKey = strings.ToLower(mentionKey)
+
+			k[mentionKey] = append(k[mentionKey], mentionableID)
+		}
+	}
+
+	// If turned on, add the user's case sensitive first name
+	if profile.NotifyProps[model.FirstNameNotifyProp] == "true" && profile.FirstName != "" {
+		k[profile.FirstName] = append(k[profile.FirstName], mentionableID)
+	}
+
+	// Add @channel and @all to k if user has them turned on and the server allows them
+	if allowChannelMentions {
+		// Ignore channel mentions if channel is muted and channel mention setting is default
+		ignoreChannelMentions := channelNotifyProps[model.IgnoreChannelMentionsNotifyProp] == model.IgnoreChannelMentionsOn || (channelNotifyProps[model.MarkUnreadNotifyProp] == model.UserNotifyMention && channelNotifyProps[model.IgnoreChannelMentionsNotifyProp] == model.IgnoreChannelMentionsDefault)
+
+		if profile.NotifyProps[model.ChannelMentionsNotifyProp] == "true" && !ignoreChannelMentions {
+			k["@channel"] = append(k["@channel"], mentionableID)
+			k["@all"] = append(k["@all"], mentionableID)
+
+			if status != nil && status.Status == model.StatusOnline {
+				k["@here"] = append(k["@here"], mentionableID)
+			}
+		}
+	}
+
+	return k
+}
+
+func (k MentionKeywords) AddUserKeyword(userID string, keyword string) MentionKeywords {
+	k[keyword] = append(k[keyword], mentionableUserID(userID))
+
+	return k
+}
+
+func (k MentionKeywords) AddGroup(group *model.Group) MentionKeywords {
+	if group.Name != nil {
+		keyword := "@" + *group.Name
+		k[keyword] = append(k[keyword], mentionableGroupID(group.Id))
+	}
+
+	return k
+}
+
+func (k MentionKeywords) AddGroupsMap(groups map[string]*model.Group) MentionKeywords {
+	for _, group := range groups {
+		k.AddGroup(group)
+	}
+
+	return k
+}
+
+type MentionParser interface {
+	ProcessText(text string)
+	Results() *MentionResults
+}
+
+// Given a post returns the values of the fields in which mentions are possible.
+// post.message, preText and text in the attachment are enabled.
+func getMentionsEnabledFields(post *model.Post) model.StringArray {
+	ret := []string{}
+
+	ret = append(ret, post.Message)
+	for _, attachment := range post.Attachments() {
+		if attachment.Pretext != "" {
+			ret = append(ret, attachment.Pretext)
+		}
+		if attachment.Text != "" {
+			ret = append(ret, attachment.Text)
+		}
+
+		for _, field := range attachment.Fields {
+			if valueString, ok := field.Value.(string); ok && valueString != "" {
+				ret = append(ret, valueString)
+			}
+		}
+	}
+	return ret
+}
+
+func (p *Plugin) IsCRTEnabledForUser(userID string) bool {
+	appCRT := *p.API.GetConfig().ServiceSettings.CollapsedThreads
+	if appCRT == model.CollapsedThreadsDisabled {
+		return false
+	}
+	if appCRT == model.CollapsedThreadsAlwaysOn {
+		return true
+	}
+	threadsEnabled := appCRT == model.CollapsedThreadsDefaultOn
+	// check if a participant has overridden collapsed threads settings
+	if preference, err := p.API.GetPreferenceForUser(userID, model.PreferenceCategoryDisplaySettings, model.PreferenceNameCollapsedThreadsEnabled); err == nil {
+		threadsEnabled = preference.Value == "on"
+	}
+	return threadsEnabled
+}
+
+// allowChannelMentions returns whether or not the channel mentions are allowed for the given post.
+func (p *Plugin) allowChannelMentions(post *model.Post, numProfiles int) bool {
+	if !p.API.HasPermissionToChannel(post.UserId, post.ChannelId, model.PermissionUseChannelMentions) {
+		return false
+	}
+
+	if post.Type == model.PostTypeHeaderChange || post.Type == model.PostTypePurposeChange {
+		return false
+	}
+
+	if int64(numProfiles) >= *p.API.GetConfig().TeamSettings.MaxNotificationsPerChannel {
+		return false
+	}
+
+	return true
+}
+
+func (p *Plugin) getMentionKeywordsInChannel(profiles map[string]*model.User, allowChannelMentions bool, channelMemberNotifyPropsMap map[string]model.StringMap, groups map[string]*model.Group) MentionKeywords {
+	keywords := make(MentionKeywords)
+
+	for _, profile := range profiles {
+		status, _ := p.API.GetUserStatus(profile.Id)
+		keywords.AddUser(
+			profile,
+			channelMemberNotifyPropsMap[profile.Id],
+			status,
+			allowChannelMentions,
+		)
+	}
+
+	keywords.AddGroupsMap(groups)
+
+	return keywords
+}
+
+func (p *Plugin) getExplicitMentionsAndKeywords(post *model.Post, channel *model.Channel, profileMap map[string]*model.User, groups map[string]*model.Group, channelMemberNotifyPropsMap map[string]model.StringMap, parentPostList *model.PostList) (*MentionResults, MentionKeywords) {
+	mentions := &MentionResults{}
+	var isAllowChannelMentions bool
+	var keywords MentionKeywords
+
+	if channel.Type == model.ChannelTypeDirect {
+		isWebhook := post.GetProp("from_webhook") == "true"
+
+		// A bot can post in a DM where it doesn't belong to.
+		// Therefore, we cannot "guess" who is the other user,
+		// so we add the mention to any user that is not the
+		// poster unless the post comes from a webhook.
+		user1, user2 := channel.GetBothUsersForDM()
+		if (post.UserId != user1) || isWebhook {
+			if _, ok := profileMap[user1]; ok {
+				mentions.addMention(user1, DMMention)
+			} else {
+				p.API.LogDebug("missing profile: DM user not in profiles", mlog.String("userId", user1), mlog.String("channelId", channel.Id))
+			}
+		}
+
+		if user2 != "" {
+			if (post.UserId != user2) || isWebhook {
+				if _, ok := profileMap[user2]; ok {
+					mentions.addMention(user2, DMMention)
+				} else {
+					p.API.LogDebug("missing profile: DM user not in profiles", mlog.String("userId", user2), mlog.String("channelId", channel.Id))
+				}
+			}
+		}
+	} else {
+		isAllowChannelMentions = p.allowChannelMentions(post, len(profileMap))
+		keywords = p.getMentionKeywordsInChannel(profileMap, isAllowChannelMentions, channelMemberNotifyPropsMap, groups)
+
+		mentions = getExplicitMentions(post, keywords)
+
+		// Add a GM mention to all members of a GM channel
+		if channel.Type == model.ChannelTypeGroup {
+			for id := range channelMemberNotifyPropsMap {
+				if _, ok := profileMap[id]; ok {
+					mentions.addMention(id, GMMention)
+				} else {
+					p.API.LogDebug("missing profile: GM user not in profiles", mlog.String("userId", id), mlog.String("channelId", channel.Id))
+				}
+			}
+		}
+
+		// Add an implicit mention when a user is added to a channel
+		// even if the user has set 'username mentions' to false in account settings.
+		if post.Type == model.PostTypeAddToChannel {
+			if addedUserId, ok := post.GetProp(model.PostPropsAddedUserId).(string); ok {
+				if _, ok := profileMap[addedUserId]; ok {
+					mentions.addMention(addedUserId, KeywordMention)
+				} else {
+					p.API.LogDebug("missing profile: user added to channel not in profiles", mlog.String("userId", addedUserId), mlog.String("channelId", channel.Id))
+				}
+			}
+		}
+
+		// Get users that have comment thread mentions enabled
+		if post.RootId != "" && parentPostList != nil {
+			for _, threadPost := range parentPostList.Posts {
+				profile := profileMap[threadPost.UserId]
+				if profile == nil {
+					// Not logging missing profile since this is relatively expected
+					continue
+				}
+
+				// If this is the root post and it was posted by an OAuth bot, don't notify the user
+				if threadPost.Id == parentPostList.Order[0] && threadPost.IsFromOAuthBot() {
+					continue
+				}
+				if p.IsCRTEnabledForUser(profile.Id) {
+					continue
+				}
+				if profile.NotifyProps[model.CommentsNotifyProp] == model.CommentsNotifyAny || (profile.NotifyProps[model.CommentsNotifyProp] == model.CommentsNotifyRoot && threadPost.Id == parentPostList.Order[0]) {
+					mentionType := ThreadMention
+					if threadPost.Id == parentPostList.Order[0] {
+						mentionType = CommentMention
+					}
+
+					mentions.addMention(threadPost.UserId, mentionType)
+				}
+			}
+		}
+
+		// Prevent the user from mentioning themselves
+		if post.GetProp("from_webhook") != "true" {
+			mentions.removeMention(post.UserId)
+		}
+	}
+
+	return mentions, keywords
+}
+
+func (p *Plugin) GetAllMentions(post *model.Post) (*MentionResults, error) {
+	// Get channel info
+	channel, err := p.API.GetChannel(post.ChannelId)
+	if err != nil {
+		p.API.LogError("Failed to get channel", "error", err.Error())
+		return nil, err
+	}
+
+	// Get user profiles for the channel
+	profiles, err := p.API.GetUsersInChannel(post.ChannelId, "username", 0, 1000)
+	if err != nil {
+		p.API.LogError("Failed to get users in channel", "error", err.Error())
+		return nil, err
+	}
+
+	// Convert profiles slice to map for easier lookup
+	profileMap := make(map[string]*model.User)
+	for _, profile := range profiles {
+		profileMap[profile.Id] = profile
+	}
+
+	// Get channel member notify properties
+	channelMemberNotifyPropsMap := make(map[string]model.StringMap)
+	members, err := p.API.GetChannelMembers(post.ChannelId, 0, 1000)
+	if err != nil {
+		p.API.LogError("Failed to get channel members", "error", err.Error())
+		return nil, err
+	}
+
+	for _, member := range members {
+		channelMemberNotifyPropsMap[member.UserId] = member.NotifyProps
+	}
+
+	// Get any parent posts if this is a reply
+	var parentPostList *model.PostList
+	if post.RootId != "" {
+		parentPostList, err = p.API.GetPostThread(post.RootId)
+		if err != nil {
+			p.API.LogError("Failed to get parent post list", "error", err.Error())
+			return nil, err
+		}
+	}
+
+	// Get groups (for group mentions)
+	// TODO: Implement a method to get groups from the channel or the team
+	// We're using an empty map for groups for simplicity
+	groupsMap := make(map[string]*model.Group)
+
+	// Extract mentions using the existing method
+	mentions, _ := p.getExplicitMentionsAndKeywords(post, channel, profileMap, groupsMap, channelMemberNotifyPropsMap, parentPostList)
+
+	return mentions, nil
+}
+
+// formatMentionsForLog converts a map of mentions to a comma-separated string for logging
+func formatMentionsForLog(mentions map[string]MentionType) string {
+	if len(mentions) == 0 {
+		return "none"
+	}
+
+	result := "["
+	first := true
+	for id, mentionType := range mentions {
+		if !first {
+			result += ", "
+		}
+		result += id + ":" + formatMentionType(mentionType)
+		first = false
+	}
+	return result + "]"
+}
+
+// formatMentionType converts a MentionType to a string representation
+func formatMentionType(mentionType MentionType) string {
+	switch mentionType {
+	case NoMention:
+		return "none"
+	case GMMention:
+		return "gm"
+	case ThreadMention:
+		return "thread"
+	case CommentMention:
+		return "comment"
+	case ChannelMention:
+		return "channel"
+	case DMMention:
+		return "dm"
+	case KeywordMention:
+		return "keyword"
+	case GroupMention:
+		return "group"
+	default:
+		return "unknown"
+	}
+}

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -2248,7 +2248,7 @@ func (tc *ClientImpl) SendUserActivity(userIDs []string, activityType, message s
 		return err
 	}
 	topic.SetSource(topicSource.(*models.TeamworkActivityTopicSource))
-	topic.SetValue(mmModel.NewPointer("Mattermost for MS Teams"))
+	topic.SetValue(mmModel.NewPointer("Mattermost"))
 	topic.SetWebUrl(mmModel.NewPointer(webURL.String()))
 
 	tc.logService.Info("Sending user activity", "webUrl", webURL.String())

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -2231,7 +2231,7 @@ func checkGroupChat(c models.Chatable, userIDs []string) *clientmodels.Chat {
 
 	return nil
 }
-func (tc *ClientImpl) SendUserActivity(userID, activityType, message string, webURL url.URL, params map[string]string) error {
+func (tc *ClientImpl) SendUserActivity(userIDs []string, activityType, message string, webURL url.URL, params map[string]string) error {
 	keyValuePairs := []models.KeyValuePairable{}
 	for k, v := range params {
 		key := k
@@ -2256,14 +2256,18 @@ func (tc *ClientImpl) SendUserActivity(userID, activityType, message string, web
 	previewText := models.NewItemBody()
 	previewText.SetContent(mmModel.NewPointer(message))
 
-	recipient := models.NewAadUserNotificationRecipient()
-	recipient.SetUserId(mmModel.NewPointer(userID))
+	var recipients []models.TeamworkNotificationRecipientable
+	for _, userID := range userIDs {
+		recipient := models.NewAadUserNotificationRecipient()
+		recipient.SetUserId(mmModel.NewPointer(userID))
+		recipients = append(recipients, recipient)
+	}
 
 	activity := teamwork.NewSendActivityNotificationToRecipientsPostRequestBody()
+	activity.SetRecipients(recipients)
 	activity.SetActivityType(mmModel.NewPointer(activityType))
 	activity.SetPreviewText(previewText)
 	activity.SetTopic(topic)
-	activity.SetRecipients([]models.TeamworkNotificationRecipientable{recipient})
 	activity.SetTemplateParameters(keyValuePairs)
 
 	err = tc.client.Teamwork().SendActivityNotificationToRecipients().Post(context.Background(), activity, nil)

--- a/server/msteams/interface.go
+++ b/server/msteams/interface.go
@@ -62,5 +62,5 @@ type Client interface {
 	ListChatMessages(chatID string, since time.Time) ([]*clientmodels.Message, error)
 	GetApp(applicationID string) (*clientmodels.App, error)
 	GetPresencesForUsers(userIDs []string) (map[string]clientmodels.Presence, error)
-	SendUserActivity(userID, activityType, message string, webURL url.URL, params map[string]string) error
+	SendUserActivity(userIDs []string, activityType, message string, webURL url.URL, params map[string]string) error
 }

--- a/server/msteams/mocks/Client.go
+++ b/server/msteams/mocks/Client.go
@@ -1028,12 +1028,12 @@ func (_m *Client) UploadFile(teamID string, channelID string, filename string, f
 }
 
 // SendUserActivity provides a mock function with given fields: userID, activityType, message, webUrl, params
-func (_m *Client) SendUserActivity(userID string, activityType string, message string, webUrl url.URL, params map[string]string) error {
-	ret := _m.Called(userID, activityType, message, webUrl, params)
+func (_m *Client) SendUserActivity(userIDs []string, activityType string, message string, webUrl url.URL, params map[string]string) error {
+	ret := _m.Called(userIDs, activityType, message, webUrl, params)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, url.URL, map[string]string) error); ok {
-		r0 = rf(userID, activityType, message, webUrl, params)
+	if rf, ok := ret.Get(0).(func([]string, string, string, url.URL, map[string]string) error); ok {
+		r0 = rf(userIDs, activityType, message, webUrl, params)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
#### Summary
mproves and refactors logic that extracts `@mentions` from the post and checks if an user should be mentioned from the received message.

Currently handling:
- DMs
- GMs
- `@user`
- `@group`
- `@channel` / `@all`
- `@here`

Missing:
- User custom keywords
- Check for user notification preferences

Requires: https://github.com/mattermost/mattermost-plugin-msteams/pull/804