### PR TITLE
feat: make the iframe navigate to the app manually

### DIFF
--- a/server/iframe.html
+++ b/server/iframe.html
@@ -14,14 +14,17 @@
     <iframe
         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;"
         title="Mattermost DevSecOps"
-        src="about:blank"
-        onload="notifyAppLoaded()">
+        src="about:blank">
     </iframe>
   <script>
     var iframe = document.querySelector('iframe');
 
     // Initialize the Microsoft Teams SDK
-    microsoftTeams.app.initialize(["{{SITE_URL}}"]);
+    microsoftTeams.app.initialize(["{{SITE_URL}}"]).then(() => {
+      microsoftTeams.app.notifySuccess();
+    }).catch((error) => {
+      console.error('Failed to initialize Microsoft Teams SDK:', error);
+    });
 
     // Define a map of tenant IDs to their corresponding domain roots
     const tenantMap = {
@@ -80,10 +83,6 @@
         iframe.src = '{{SITE_URL}}';
       }
     });
-
-    function notifyAppLoaded() {
-      return microsoftTeams.app.notifySuccess();
-    }
   </script>
 </body>
 </html>

--- a/server/iframe.html
+++ b/server/iframe.html
@@ -51,8 +51,19 @@
         // and send it to the iframe to redirect the user to what triggered the notification.
         if (context && context.page && context.page.subPageId) {
           params.set('sub_entity_id', context.page.subPageId);
+
+          // Since we received a sub_entity_id, redirect to the subEntityId page.
+          try {
+            microsoftTeams.app.openLink(
+              `https://teams.microsoft.com/l/entity/${context.app.appId.appIdAsString}/?context=` + JSON.stringify({
+                subEntityId: context.page.subPageId
+              })
+            );
+          } catch (error) {
+            console.error('Failed to open link, fallback to using the iframe.', error);
+          }
         }
-  
+
         microsoftTeams.authentication.getAuthToken()
           .then((token) => {
             params.set('token', token);

--- a/server/iframe.html
+++ b/server/iframe.html
@@ -38,7 +38,6 @@
         tenantId = context.user.tenant.id;
       }
 
-      
       // If there's an explicit match in the tenant map, try to get auth token
       if (tenantMap[tenantId]) {
         const domainRoot = tenantMap[tenantId];
@@ -52,16 +51,18 @@
         if (context && context.page && context.page.subPageId) {
           params.set('sub_entity_id', context.page.subPageId);
 
-          // Since we received a sub_entity_id, redirect to the subEntityId page.
-          try {
-            microsoftTeams.app.openLink(
-              `https://teams.microsoft.com/l/entity/${context.app.appId.appIdAsString}/?context=` + JSON.stringify({
-                subEntityId: context.page.subPageId
-              })
-            );
-          } catch (error) {
+          // Since we received a sub_entity_id, redirect to the subEntityId page manually using the Microsoft Teams SDK.
+          // This is a workaround so we send the user to the tab application when opening the link from the 
+          // Microsoft Teams User Activity notifications page.
+          // Trying to navigate to the app within the app seems to be a no-op from the SDK, which is good for us.
+          microsoftTeams.pages.navigateToApp({
+            appId: context.app.appId.appIdAsString,
+            subPageId: context.page.subPageId
+          }).then(() => {
+            console.log("Successfully opened link, redirecting to the tab application.");
+          }).catch((error) => {
             console.error('Failed to open link, fallback to using the iframe.', error);
-          }
+          });
         }
 
         microsoftTeams.authentication.getAuthToken()

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -2248,7 +2248,7 @@ func (tc *ClientImpl) SendUserActivity(userIDs []string, activityType, message s
 		return err
 	}
 	topic.SetSource(topicSource.(*models.TeamworkActivityTopicSource))
-	topic.SetValue(mmModel.NewPointer("Mattermost for MS Teams"))
+	topic.SetValue(mmModel.NewPointer("Mattermost"))
 	topic.SetWebUrl(mmModel.NewPointer(webURL.String()))
 
 	tc.logService.Info("Sending user activity", "webUrl", webURL.String())


### PR DESCRIPTION
#### Summary
This PR relies on `navigateToApp` to redirect the user to the deeplink manually when we receive a `subEntityId` that comes from an userActivity.

This fires of if the parameter is set, so when an user activity is opened in the "Activities" tab application, teams will "redirect" the user to the Mattermost tab application, and then the tab will load as usual.

Out tab app will also load this code and fire the `navigateToApp` call, but from my testing it seems that the Teams SDK is smart enough to avoid navigating to the page the user is already in, becoming a no-op in our tab application loading the iframe URL as usual.
