### PR TITLE
Bump mockery version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,7 +410,7 @@ endif
 ## Build the generated code
 generate: export PATH := $(GOBIN):$(PATH)
 generate:
-	$(GO) install github.com/vektra/mockery/v2/...@v2.18.0
+	$(GO) install github.com/vektra/mockery/v2/...@v2.42.2
 	cd server && $(GO) generate ./...
 
 # Help documentation à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html


### PR DESCRIPTION

#### Summary
Fixes crash in mockery.

```
❯ make generate
/usr/local/go/bin/go install github.com/vektra/mockery/v2/...@v2.18.0
go: downloading github.com/vektra/mockery/v2 v2.18.0
go: downloading golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
go: downloading golang.org/x/tools v0.5.0
go: downloading github.com/chigopher/pathlib v0.12.0
go: downloading github.com/spf13/viper v1.12.0
go: downloading github.com/rs/zerolog v1.27.0
go: downloading github.com/spf13/cobra v1.4.0
go: downloading github.com/stretchr/testify v1.7.2
go: downloading github.com/subosito/gotenv v1.4.0
go: downloading github.com/spf13/cast v1.5.0
go: downloading github.com/spf13/afero v1.8.2
go: downloading github.com/fsnotify/fsnotify v1.5.4
go: downloading github.com/magiconair/properties v1.8.6
go: downloading github.com/spf13/jwalterweatherman v1.1.0
go: downloading gopkg.in/ini.v1 v1.66.6
go: downloading github.com/pelletier/go-toml/v2 v2.0.2
go: downloading golang.org/x/sys v0.4.0
go: downloading github.com/stretchr/objx v0.1.1
go: downloading github.com/mattn/go-colorable v0.1.12
go: downloading golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
go: downloading github.com/mattn/go-isatty v0.0.14
go: downloading golang.org/x/mod v0.7.0
cd server && /usr/local/go/bin/go generate ./...
26 Mar 25 09:23 EDT INF Starting mockery dry-run=false version=v2.18.0
26 Mar 25 09:23 EDT INF Using config:  dry-run=false version=v2.18.0
26 Mar 25 09:23 EDT INF Walking dry-run=false version=v2.18.0
26 Mar 25 09:23 EDT INF Generating mock dry-run=false interface=Metrics qualified-name=github.com/mattermost/mattermost-plugin-msteams/server/metrics version=v2.18.0
26 Mar 25 09:23 EDT INF Starting mockery dry-run=false version=v2.18.0
26 Mar 25 09:23 EDT INF Using config:  dry-run=false version=v2.18.0
26 Mar 25 09:23 EDT INF Walking dry-run=false version=v2.18.0
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7a732f]

goroutine 14 [running]:
go/types.(*Checker).handleBailout(0xc0005fe800, 0xc00d2f5c10)
	/usr/local/go/src/go/types/check.go:367 +0x88
panic({0x8cb420?, 0xd35830?})
	/usr/local/go/src/runtime/panic.go:770 +0x132
go/types.(*StdSizes).Sizeof(0x0, {0xa2bf80, 0xd3a780})
	/usr/local/go/src/go/types/sizes.go:228 +0x30f
go/types.(*Config).sizeof(...)
	/usr/local/go/src/go/types/sizes.go:333
go/types.representableConst.func1({0xa2bf80?, 0xd3a780?})
	/usr/local/go/src/go/types/const.go:76 +0x9e
go/types.representableConst({0xa2e850, 0xc00d1cd378}, 0xc0005fe800, 0xd3a780, 0xc00d2f24a8)
	/usr/local/go/src/go/types/const.go:92 +0x192
go/types.(*Checker).representation(0xc0005fe800, 0xc00d2f6800, 0xd3a780)
	/usr/local/go/src/go/types/const.go:256 +0x65
go/types.(*Checker).implicitTypeAndValue(0xc0005fe800, 0xc00d2f6800, {0xa2bf80, 0xd3a780})
	/usr/local/go/src/go/types/expr.go:375 +0x2d7
go/types.(*Checker).assignment(0xc0005fe800, 0xc00d2f6800, {0xa2bf80, 0xd3a780}, {0x945845, 0xa})
	/usr/local/go/src/go/types/assignments.go:52 +0x2e5
go/types.(*Checker).assignVar(0xc0005fe800, {0xa2db58, 0xc008a849a8}, {0xa2e0c8, 0xc00d12ca40}, 0x0, {0x945845, 0xa})
	/usr/local/go/src/go/types/assignments.go:260 +0x1d8
go/types.(*Checker).assignVars(0xc0005fe800, {0xc00d116690?, 0x1, 0x0?}, {0xc00d1166a0, 0xc00d2e0a88?, 0xc00d2f2988?})
	/usr/local/go/src/go/types/assignments.go:455 +0x310
go/types.(*Checker).stmt(0xc0005fe800, 0x1, {0xa2ddc8, 0xc00d12e2c0})
	/usr/local/go/src/go/types/stmt.go:476 +0x1628
go/types.(*Checker).stmtList(0xc0005fe800, 0x1, {0xc00d1166b0?, 0x93e569?, 0x5?})
	/usr/local/go/src/go/types/stmt.go:121 +0x85
go/types.(*Checker).stmt(0xc0005fe800, 0x1, {0xa2dee8, 0xc00d11f080})
	/usr/local/go/src/go/types/stmt.go:562 +0x20f2
go/types.(*Checker).stmt(0xc0005fe800, 0x11, {0xa2df18, 0xc00d12e300})
	/usr/local/go/src/go/types/stmt.go:574 +0x3017
go/types.(*Checker).stmtList(0xc0005fe800, 0x11, {0xc00d12ca60?, 0xa32ea0?, 0x927320?})
	/usr/local/go/src/go/types/stmt.go:121 +0x85
go/types.(*Checker).stmt(0xc0005fe800, 0x0, {0xa2dfa8, 0xc00d11f0e0})
	/usr/local/go/src/go/types/stmt.go:737 +0x38b4
go/types.(*Checker).stmtList(0xc0005fe800, 0x0, {0xc00d122300?, 0x0?, 0x456fde?})
	/usr/local/go/src/go/types/stmt.go:121 +0x85
go/types.(*Checker).funcBody(0xc0005fe800, 0xa2bdf0?, {0xc001d341c8?, 0xc000184070?}, 0xc00d26f480, 0xc00d11f110, {0x0?, 0x0?})
	/usr/local/go/src/go/types/stmt.go:41 +0x331
go/types.(*Checker).funcDecl.func1()
	/usr/local/go/src/go/types/decl.go:852 +0x3a
go/types.(*Checker).processDelayed(0xc0005fe800, 0x0)
	/usr/local/go/src/go/types/check.go:467 +0x162
go/types.(*Checker).checkFiles(0xc0005fe800, {0xc00d054f48, 0x3, 0x3})
	/usr/local/go/src/go/types/check.go:411 +0x1cc
go/types.(*Checker).Files(...)
	/usr/local/go/src/go/types/check.go:372
golang.org/x/tools/go/packages.(*loader).loadPackage(0xc0000fa380, 0xc0013d2cc0)
	/home/dlauder/go/pkg/mod/golang.org/x/tools@v0.5.0/go/packages/packages.go:1044 +0x94a
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1()
	/home/dlauder/go/pkg/mod/golang.org/x/tools@v0.5.0/go/packages/packages.go:851 +0x1a9
sync.(*Once).doSlow(0x0?, 0x0?)
	/usr/local/go/src/sync/once.go:74 +0xc2
sync.(*Once).Do(...)
	/usr/local/go/src/sync/once.go:65
golang.org/x/tools/go/packages.(*loader).loadRecursive(0x0?, 0x0?)
	/home/dlauder/go/pkg/mod/golang.org/x/tools@v0.5.0/go/packages/packages.go:839 +0x4a
golang.org/x/tools/go/packages.(*loader).refine.func2(0x0?)
	/home/dlauder/go/pkg/mod/golang.org/x/tools@v0.5.0/go/packages/packages.go:774 +0x26
created by golang.org/x/tools/go/packages.(*loader).refine in goroutine 1
	/home/dlauder/go/pkg/mod/golang.org/x/tools@v0.5.0/go/packages/packages.go:773 +0xccf
msteams/interface.go:1: running "mockery": exit status 2
26 Mar 25 09:23 EDT INF Starting mockery dry-run=false version=v2.18.0
26 Mar 25 09:23 EDT INF Using config:  dry-run=false version=v2.18.0
26 Mar 25 09:23 EDT INF Walking dry-run=false version=v2.18.0
26 Mar 25 09:23 EDT INF Generating mock dry-run=false interface=Store qualified-name=github.com/mattermost/mattermost-plugin-msteams/server/store version=v2.18.0
make: *** [Makefile:414: generate] Error 1
```

#### Ticket Link
NONE