### PR TITLE
Update golangci-lint version to match MM server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ apply:
 ## Install go tools
 install-go-tools:
 	@echo Installing go tools
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.7
 	$(GO) install gotest.tools/gotestsum@v1.7.0
 	$(GO) install github.com/mattermost/mattermost-govet/v2@3f08281c344327ac09364f196b15f9a81c7eff08
 


### PR DESCRIPTION
#### Summary
Fixes running `make check-style` locally:
```
Error: can't load config: the Go language version (go1.22) used to build golangci-lint is lower than the targeted Go version (1.23.1)
Failed executing command with error: can't load config: the Go language version (go1.22) used to build golangci-lint is lower than the targeted Go version (1.23.1)
```
#### Ticket Link
NONE