### PR TITLE
Disable sync job via plugin config

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -20,6 +20,13 @@
     "footer": "",
     "settings": [
       {
+        "key": "enableSyncJob",
+        "display_name": "Enable sync job",
+        "type": "bool",
+        "help_text": "When false, disables the sync job that creates and maintains chat and channel subscriptions",
+        "default": true
+      },
+      {
         "key": "tenantId",
         "display_name": "Tenant ID",
         "type": "text",

--- a/plugin.json
+++ b/plugin.json
@@ -20,11 +20,11 @@
     "footer": "",
     "settings": [
       {
-        "key": "enableSyncJob",
-        "display_name": "Enable sync job",
+        "key": "disableSyncJob",
+        "display_name": "Disable sync job",
         "type": "bool",
-        "help_text": "When false, disables the sync job that creates and maintains chat and channel subscriptions",
-        "default": true
+        "help_text": "When true, disables the sync job that creates and maintains chat and channel subscriptions",
+        "default": false
       },
       {
         "key": "tenantId",

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -23,6 +23,7 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
+	EnableSyncJob                   bool   `json:"enableSyncJob"`
 	TenantID                        string `json:"tenantid"`
 	ClientID                        string `json:"clientid"`
 	ClientSecret                    string `json:"clientsecret"`

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -23,7 +23,7 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
-	EnableSyncJob                   bool   `json:"enableSyncJob"`
+	DisableSyncJob                  bool   `json:"disableSyncJob"`
 	TenantID                        string `json:"tenantid"`
 	ClientID                        string `json:"clientid"`
 	ClientSecret                    string `json:"clientsecret"`

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -5,9 +5,7 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"runtime/debug"
-	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost-plugin-msteams/server/metrics"
@@ -56,11 +54,6 @@ func (m *Monitor) Start() error {
 	// Close the previous background job if exists.
 	m.Stop()
 
-	if !m.IsEnabled() {
-		m.api.LogInfo("Monitoring system job is disabled via env var.")
-		return nil
-	}
-
 	job, jobErr := cluster.Schedule(
 		m.api,
 		monitoringSystemJobName,
@@ -83,16 +76,6 @@ func (m *Monitor) Stop() {
 			m.api.LogError("Failed to close monitoring system background job", "error", err)
 		}
 	}
-}
-
-func (m *Monitor) IsEnabled() bool {
-	// The job can be disabled via an environment variable
-	val := os.Getenv("MM_TEAMS_SYNC_MONITORING_SYSTEM_DISABLED")
-	val = strings.ToLower(strings.TrimSpace(val))
-	if val == "true" || val == "1" {
-		return false
-	}
-	return true
 }
 
 // runMonitoringSystemJob is a callback to trigger the business logic of the Monitor job, being run

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -5,7 +5,9 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost-plugin-msteams/server/metrics"
@@ -54,6 +56,11 @@ func (m *Monitor) Start() error {
 	// Close the previous background job if exists.
 	m.Stop()
 
+	if !m.IsEnabled() {
+		m.api.LogInfo("Monitoring system job is disabled via env var.")
+		return nil
+	}
+
 	job, jobErr := cluster.Schedule(
 		m.api,
 		monitoringSystemJobName,
@@ -76,6 +83,16 @@ func (m *Monitor) Stop() {
 			m.api.LogError("Failed to close monitoring system background job", "error", err)
 		}
 	}
+}
+
+func (m *Monitor) IsEnabled() bool {
+	// The job can be disabled via an environment variable
+	val := os.Getenv("MM_TEAMS_SYNC_MONITORING_SYSTEM_DISABLED")
+	val = strings.ToLower(strings.TrimSpace(val))
+	if val == "true" || val == "1" {
+		return false
+	}
+	return true
 }
 
 // runMonitoringSystemJob is a callback to trigger the business logic of the Monitor job, being run

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -282,7 +282,7 @@ func (p *Plugin) start(isRestart bool) {
 		return
 	}
 
-	if p.configuration.EnableSyncJob {
+	if !p.configuration.DisableSyncJob {
 		p.monitor = NewMonitor(p.GetClientForApp(), p.store, p.API, p.GetMetrics(), p.GetURL()+"/", p.getConfiguration().WebhookSecret, p.getConfiguration().EvaluationAPI)
 		if err = p.monitor.Start(); err != nil {
 			p.API.LogError("Unable to start the monitoring system", "error", err.Error())
@@ -295,7 +295,7 @@ func (p *Plugin) start(isRestart bool) {
 	p.stopSubscriptions = stop
 	p.stopContext = ctx
 
-	if !p.getConfiguration().DisableCheckCredentials && p.configuration.EnableSyncJob {
+	if !p.getConfiguration().DisableCheckCredentials && !p.configuration.DisableSyncJob {
 		checkCredentialsJob, jobErr := cluster.Schedule(
 			p.API,
 			checkCredentialsJobName,

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -282,16 +282,20 @@ func (p *Plugin) start(isRestart bool) {
 		return
 	}
 
-	p.monitor = NewMonitor(p.GetClientForApp(), p.store, p.API, p.GetMetrics(), p.GetURL()+"/", p.getConfiguration().WebhookSecret, p.getConfiguration().EvaluationAPI)
-	if err = p.monitor.Start(); err != nil {
-		p.API.LogError("Unable to start the monitoring system", "error", err.Error())
+	if p.configuration.EnableSyncJob {
+		p.monitor = NewMonitor(p.GetClientForApp(), p.store, p.API, p.GetMetrics(), p.GetURL()+"/", p.getConfiguration().WebhookSecret, p.getConfiguration().EvaluationAPI)
+		if err = p.monitor.Start(); err != nil {
+			p.API.LogError("Unable to start the monitoring system", "error", err.Error())
+		}
+	} else {
+		p.API.LogInfo("Sync job disabled via config")
 	}
 
 	ctx, stop := context.WithCancel(context.Background())
 	p.stopSubscriptions = stop
 	p.stopContext = ctx
 
-	if !p.getConfiguration().DisableCheckCredentials && p.monitor.IsEnabled() {
+	if !p.getConfiguration().DisableCheckCredentials && p.configuration.EnableSyncJob {
 		checkCredentialsJob, jobErr := cluster.Schedule(
 			p.API,
 			checkCredentialsJobName,

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -291,7 +291,7 @@ func (p *Plugin) start(isRestart bool) {
 	p.stopSubscriptions = stop
 	p.stopContext = ctx
 
-	if !p.getConfiguration().DisableCheckCredentials {
+	if !p.getConfiguration().DisableCheckCredentials && p.monitor.IsEnabled() {
 		checkCredentialsJob, jobErr := cluster.Schedule(
 			p.API,
 			checkCredentialsJobName,


### PR DESCRIPTION
#### Summary
Provides a way to disable the sync job thus avoiding error logs and unneeded Graph API calls.

To disable, set the `Enable sync job` to false via plugin config in the system console. 

#### Ticket Link
NONE