### PR TITLE
fix: check tenant id before adding the one being set up

### DIFF
--- a/server/iframe.html
+++ b/server/iframe.html
@@ -32,8 +32,14 @@
       'd2888234-d303-4c94-8f45-c7348f089048': 'https://msteams-sync-test.test.mattermost.cloud',
       '7419f71d-0b07-4d0a-89b8-3a4be2ec8627': 'https://hub.mattermost.com',
       '8bcff170-9979-491e-8683-d8ced0850bad': 'https://servicenow.cloud.mattermost.com',
-      '{{.TenantID}}': '{{.SiteURL}}'
     };
+
+    {{ if .TenantID }}
+      // Check if tenantMap already has the configured tenant ID, if not, add it.
+      if (!tenantMap['{{.TenantID}}']) {
+        tenantMap['{{.TenantID}}'] = '{{.SiteURL}}';
+      }
+    {{ end }}
 
     // Choose the iFrame content based on the tenant.
     microsoftTeams.app.getContext().then((context) => {


### PR DESCRIPTION
#### Summary
Check if the Tenant ID in the configuration is already hardcoded in the `tenantMap` before adding it.