### PR TITLE
skip assets.go when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,7 @@ ifneq ($(wildcard NOTICE.txt),)
 endif
 ifneq ($(wildcard $(ASSETS_DIR)/.),)
 	cp -r $(ASSETS_DIR) dist/$(PLUGIN_ID)/
+	rm -f dist/$(PLUGIN_ID)/$(ASSETS_DIR)/assets.go
 endif
 ifneq ($(HAS_PUBLIC),)
 	cp -r public dist/$(PLUGIN_ID)/


### PR DESCRIPTION
#### Summary
Don't bundle `assets/asset.go` into the final plugin distribution: this is used exclusively to compile certain assets into the resulting binary, but when included in `assets/` it gets copied into the server's plugin directory. In production, this is harmless, but for developers, this trips up `make check-style` which sees the file doesn't conform with the monorepo style.

#### Ticket Link
None