### PR TITLE
fix: sso audience and other minor fixes

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-msteams/server/metrics"
 	"github.com/mattermost/mattermost-plugin-msteams/server/msteams"
 	"github.com/mattermost/mattermost-plugin-msteams/server/store"
+	"github.com/mattermost/mattermost-plugin-msteams/server/store/pluginstore"
 	"github.com/mattermost/mattermost-plugin-msteams/server/store/storemodels"
 	"github.com/sirupsen/logrus"
 
@@ -30,9 +31,10 @@ import (
 )
 
 type API struct {
-	p      *Plugin
-	store  store.Store
-	router *mux.Router
+	p           *Plugin
+	store       store.Store
+	pluginStore *pluginstore.PluginStore
+	router      *mux.Router
 }
 
 type Activities struct {
@@ -57,11 +59,11 @@ type UpdateWhitelistResult struct {
 	FailedLines []string `json:"failedLines"`
 }
 
-func NewAPI(p *Plugin, store store.Store) *API {
+func NewAPI(p *Plugin, store store.Store, pluginStore *pluginstore.PluginStore) *API {
 	router := mux.NewRouter()
 	p.handleStaticFiles(router)
 
-	api := &API{p: p, router: router, store: store}
+	api := &API{p: p, router: router, store: store, pluginStore: pluginStore}
 
 	if p.GetMetrics() != nil {
 		// set error counter middleware handler

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -350,10 +350,6 @@ func getCookieDomain(config *model.Config) string {
 	return ""
 }
 
-func getUserPropKey(key string) string {
-	return "com.mattermost.plugin-msteams-devsecops." + key
-}
-
 // getRedirectPathFromUser generates a redirect path for the user based on the subEntityID.
 // This is used to redirect the user to the correct URL when they click on a notification in Microsoft Teams.
 func (p *Plugin) getRedirectPathFromUser(logger logrus.FieldLogger, user *model.User, subEntityID string) string {

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -234,13 +234,13 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 
 	// Keep track of the unique_name and oid in the user's properties to support
 	// notifications in the future.
-	mmUser.Props[getUserPropKey("sso_username")] = ssoUsername
-	mmUser.Props[getUserPropKey("oid")] = oid
+	mmUser.Props[getUserPropKey(TeamsPropertySSOUsername)] = ssoUsername
+	mmUser.Props[getUserPropKey(TeamsPropertyObjectID)] = oid
 	appID := r.URL.Query().Get("app_id")
 	if appID == "" {
 		logger.Error("App ID was not sent with the authentication request")
 	} else {
-		mmUser.Props[getUserPropKey("app_id")] = appID
+		mmUser.Props[getUserPropKey(TeamsPropertyAppID)] = appID
 	}
 
 	// Update the user with the claims

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/mattermost/mattermost-plugin-msteams/server/store/pluginstore"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	pluginapi "github.com/mattermost/mattermost/server/public/pluginapi"
@@ -234,19 +235,22 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 
 	// Keep track of the unique_name and oid in the user's properties to support
 	// notifications in the future.
-	mmUser.Props[getUserPropKey(TeamsPropertySSOUsername)] = ssoUsername
-	mmUser.Props[getUserPropKey(TeamsPropertyObjectID)] = oid
+	storedUser := pluginstore.NewUser(mmUser.Id, oid, ssoUsername)
+	err = a.p.pluginStore.StoreUser(storedUser)
+	if err != nil {
+		logger.WithError(err).Error("Failed to store user")
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
 	appID := r.URL.Query().Get("app_id")
 	if appID == "" {
 		logger.Error("App ID was not sent with the authentication request")
-	} else {
-		mmUser.Props[getUserPropKey(TeamsPropertyAppID)] = appID
 	}
 
-	// Update the user with the claims
-	err = a.p.apiClient.User.Update(mmUser)
+	err = a.p.pluginStore.StoreAppID(appID)
 	if err != nil {
-		logger.WithError(err).Error("Failed to update Mattermost user with claims")
+		logger.WithError(err).Error("Failed to store app ID")
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -326,7 +330,7 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 		return
 	}
 
-	parser := NewNotificationsParser(p.API, p.msteamsAppClient)
+	parser := NewNotificationsParser(p.API, p.pluginStore, p.msteamsAppClient)
 	if err := parser.ProcessPost(post); err != nil {
 		p.API.LogError("Failed to process mentions", "error", err.Error())
 		return

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -177,7 +177,7 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 
 	// Validate the token in the request, handling all errors if invalid.
 	expectedTenantIDs := []string{a.p.getConfiguration().TenantID}
-	claims, validationErr := validateToken(a.p.tabAppJWTKeyFunc, token, expectedTenantIDs, enableDeveloper != nil && *enableDeveloper)
+	claims, validationErr := validateToken(a.p.tabAppJWTKeyFunc, token, expectedTenantIDs, enableDeveloper != nil && *enableDeveloper, *config.ServiceSettings.SiteURL, a.p.configuration.ClientID)
 	if validationErr != nil {
 		handleErrorWithCode(logger, w, validationErr.StatusCode, validationErr.Message, validationErr.Err)
 		return

--- a/server/iframe.html
+++ b/server/iframe.html
@@ -18,7 +18,6 @@
     </iframe>
   <script>
     var iframe = document.querySelector('iframe');
-    console.log("{{.SiteURL}}");
 
     // Initialize the Microsoft Teams SDK
     microsoftTeams.app.initialize(["{{.SiteURL}}"]).then(() => {
@@ -83,6 +82,9 @@
         console.log('No tenant match found, redirecting to default site');
         iframe.src = '{{.SiteURL}}';
       }
+    }).catch((error) => {
+      console.error('Failed to get context:', error);
+      iframe.src = '{{.SiteURL}}';
     });
   </script>
 </body>

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -5,7 +5,9 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/google/uuid"
 
@@ -17,7 +19,7 @@ import (
 
 const (
 	MicrosoftOnlineJWKSURL = "https://login.microsoftonline.com/common/discovery/v2.0/keys"
-	ExpectedAudience       = "api://community.mattermost.com/4ef56ea2-4a2f-4817-a6e0-a7cd760e2034"
+	ExpectedAudienceFmt    = "api://%s/%s"
 )
 
 type validationError struct {
@@ -43,7 +45,7 @@ func setupJWKSet() (keyfunc.Keyfunc, context.CancelFunc) {
 	return k, cancelCtx
 }
 
-func validateToken(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs []string, enableDeveloper bool) (jwt.MapClaims, *validationError) {
+func validateToken(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs []string, enableDeveloper bool, siteURL, clientID string) (jwt.MapClaims, *validationError) {
 	if token == "" && enableDeveloper {
 		logrus.Warn("Skipping token validation check for empty token since developer mode enabled")
 		return nil, nil
@@ -82,11 +84,20 @@ func validateToken(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs [
 		// There's no WithNotBefore() helper, but the library always verifies if the claim is present.
 	}
 
+	mmServerURL, err := url.Parse(siteURL)
+	if err != nil {
+		logrus.WithError(err).WithField("site_url", siteURL).Warn("Failed to parse site URL, check your system console")
+		return nil, &validationError{
+			StatusCode: http.StatusUnauthorized,
+			Message:    "Failed to authenticate due to Mattermost server missconfiguration. Contact your system administrator.",
+		}
+	}
+
 	// Verify that this token was signed for the expected app, unless developer mode is enabled.
 	if enableDeveloper {
 		logrus.Warn("Skipping aud claim check for token since developer mode enabled")
 	} else {
-		options = append(options, jwt.WithAudience(ExpectedAudience))
+		options = append(options, jwt.WithAudience(fmt.Sprintf(ExpectedAudienceFmt, mmServerURL.Host, clientID)))
 	}
 
 	parsed, err := jwt.Parse(
@@ -161,6 +172,7 @@ func validateToken(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs [
 	for _, expectedTenantID := range expectedTenantIDs {
 		if claims["tid"] == expectedTenantID {
 			logger.Info("Validated token, and authorized request from matching tenant")
+			logger.Info("Claim tenant id: ", claims["tid"])
 			return claims, nil
 		} else if enableDeveloper && expectedTenantID == "*" {
 			logger.Warn("Validated token, but authorized request from wildcard tenant since developer mode enabled")

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -172,7 +172,6 @@ func validateToken(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs [
 	for _, expectedTenantID := range expectedTenantIDs {
 		if claims["tid"] == expectedTenantID {
 			logger.Info("Validated token, and authorized request from matching tenant")
-			logger.Info("Claim tenant id: ", claims["tid"])
 			return claims, nil
 		} else if enableDeveloper && expectedTenantID == "*" {
 			logger.Warn("Validated token, but authorized request from wildcard tenant since developer mode enabled")

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -164,7 +163,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 				"tid": tid,
 			})
 			jwtToken.Header[jwkset.HeaderKID] = keyWithoutAlgID
@@ -185,7 +184,7 @@ func TestValidateToken(t *testing.T) {
 			token := newToken(t, priv, jwt.MapClaims{
 				"exp": future(),
 				"nbf": past(),
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 				"tid": tid,
 			})
 			expectedTenantIDs := []string{tid}
@@ -203,7 +202,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": "invalid",
 				"exp": future(),
 				"nbf": past(),
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 				"tid": tid,
 			})
 			expectedTenantIDs := []string{tid}
@@ -221,7 +220,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": future(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 				"tid": tid,
 			})
 			expectedTenantIDs := []string{tid}
@@ -239,7 +238,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"nbf": past(),
 				"tid": tid,
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 			})
 			expectedTenantIDs := []string{tid}
 
@@ -257,7 +256,7 @@ func TestValidateToken(t *testing.T) {
 				"exp": "invalid",
 				"nbf": past(),
 				"tid": tid,
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 			})
 			expectedTenantIDs := []string{tid}
 
@@ -275,7 +274,7 @@ func TestValidateToken(t *testing.T) {
 				"exp": past(),
 				"nbf": past(),
 				"tid": tid,
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 			})
 			expectedTenantIDs := []string{tid}
 
@@ -292,7 +291,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"tid": tid,
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 			})
 			expectedTenantIDs := []string{tid}
 
@@ -310,7 +309,7 @@ func TestValidateToken(t *testing.T) {
 				"exp": future(),
 				"nbf": "invalid",
 				"tid": tid,
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 			})
 			expectedTenantIDs := []string{tid}
 
@@ -328,7 +327,7 @@ func TestValidateToken(t *testing.T) {
 				"exp": future(),
 				"nbf": future(),
 				"tid": tid,
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 			})
 			expectedTenantIDs := []string{tid}
 
@@ -367,7 +366,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 				"tid": wrongTid,
 			})
 			expectedTenantIDs := []string{}
@@ -386,7 +385,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 				"tid": wrongTid,
 			})
 			expectedTenantIDs := []string{expectedTid}
@@ -406,7 +405,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 				"tid": wrongTid,
 			})
 			expectedTenantIDs := []string{expectedTid1, expectedTid2}
@@ -424,7 +423,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 				"tid": tid,
 			})
 			expectedTenantIDs := []string{tid}
@@ -442,7 +441,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 				"tid": expectedTid1,
 			})
 			expectedTenantIDs := []string{expectedTid1, expectedTid2}
@@ -459,7 +458,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
+				"aud": ExpectedAudience,
 				"tid": developerTid,
 			})
 			expectedTenantIDs := []string{"*"}

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -76,7 +76,7 @@ func (p *NotificationsParser) ProcessPost(post *model.Post) error {
 			}
 
 			if m.User == nil && m.Group == nil {
-				p.PAPI.LogDebug("Failed to find user or group for metnion", "mention", mention)
+				p.PAPI.LogDebug("Failed to find user or group for mention", "mention", mention)
 				continue
 			}
 		}
@@ -84,6 +84,8 @@ func (p *NotificationsParser) ProcessPost(post *model.Post) error {
 		p.Notifications = append(p.Notifications, m)
 	}
 
+	// Handle messages in direct and group channels, since those are not mentions.
+	// TODO: Avoid repeating notifications if the message contains a mention.
 	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
 		p.Notifications = append(p.Notifications, &UserNotification{
 			Trigger: post.Message,
@@ -209,6 +211,7 @@ func (p *NotificationsParser) sendChannelNotification(un *UserNotification, onli
 
 	users := []*model.User{}
 	for _, member := range channelMembers {
+		// Avoid sending notifications to the user who posted the message even if it's part of the channel
 		if member.UserId == un.Post.UserId {
 			continue
 		}

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -15,6 +15,12 @@ import (
 	"github.com/mattermost/mattermost/server/public/plugin"
 )
 
+const (
+	TeamsPropertyObjectID    = "oid"
+	TeamsPropertyAppID       = "app_id"
+	TeamsPropertySSOUsername = "sso_username"
+)
+
 type UserNotification struct {
 	Trigger    string
 	Post       *model.Post
@@ -260,20 +266,14 @@ func (p *NotificationsParser) sendUserActivity(userActivity *UserActivity) error
 	var appID string
 	msteamsUserIDs := []string{}
 	for _, user := range userActivity.Users {
-		u, err := p.PAPI.GetUser(user.Id)
-		if err != nil {
-			p.PAPI.LogError("Failed to get user", "error", err.Error())
-			continue
-		}
-
-		msteamsUserID, exists := u.GetProp(getUserPropKey("user_id"))
+		msteamsUserID, exists := user.GetProp(getUserPropKey(TeamsPropertyObjectID))
 		if !exists {
 			continue
 		}
 		msteamsUserIDs = append(msteamsUserIDs, msteamsUserID)
 
 		if appID == "" {
-			appID, _ = u.GetProp(getUserPropKey("app_id"))
+			appID, _ = user.GetProp(getUserPropKey(TeamsPropertyAppID))
 		}
 	}
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-msteams/server/msteams/client_disconnectionlayer"
 	client_timerlayer "github.com/mattermost/mattermost-plugin-msteams/server/msteams/client_timerlayer"
 	"github.com/mattermost/mattermost-plugin-msteams/server/store"
+	"github.com/mattermost/mattermost-plugin-msteams/server/store/pluginstore"
 	sqlstore "github.com/mattermost/mattermost-plugin-msteams/server/store/sqlstore"
 	timerlayer "github.com/mattermost/mattermost-plugin-msteams/server/store/timerlayer"
 	"github.com/mattermost/mattermost/server/public/model"
@@ -91,6 +92,8 @@ type Plugin struct {
 	cancelKeyFunc     context.CancelFunc
 	cancelKeyFuncLock sync.Mutex
 	tabAppJWTKeyFunc  keyfunc.Keyfunc
+
+	pluginStore *pluginstore.PluginStore
 }
 
 func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Request) {
@@ -482,7 +485,9 @@ func (p *Plugin) onActivate() error {
 		}
 	}
 
-	p.apiHandler = NewAPI(p, p.store)
+	p.pluginStore = pluginstore.NewPluginStore(p.API)
+
+	p.apiHandler = NewAPI(p, p.store, p.pluginStore)
 
 	if err := p.validateConfiguration(p.getConfiguration()); err != nil {
 		return err

--- a/server/store/pluginstore/store.go
+++ b/server/store/pluginstore/store.go
@@ -1,0 +1,95 @@
+package pluginstore
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mattermost/mattermost/server/public/plugin"
+)
+
+type User struct {
+	MattermostUserID string
+	TeamsObjectID    string
+	TeamsSSOUsername string
+}
+
+func NewUser(mattermostUserID, teamsObjectID, teamsSSOUsername string) *User {
+	return &User{
+		MattermostUserID: mattermostUserID,
+		TeamsObjectID:    teamsObjectID,
+		TeamsSSOUsername: teamsSSOUsername,
+	}
+}
+
+type Store interface {
+	StoreUser(user *User) error
+	GetUser(mattermostUserID string) (*User, error)
+	StoreAppID(appID string) error
+	GetAppID() (string, error)
+}
+
+type PluginStore struct {
+	API plugin.API
+}
+
+func NewPluginStore(api plugin.API) *PluginStore {
+	return &PluginStore{API: api}
+}
+
+func (s *PluginStore) StoreUser(user *User) error {
+	value, err := json.Marshal(user)
+	if err != nil {
+		return err
+	}
+
+	appErr := s.API.KVSet(getUserKey(user.MattermostUserID), value)
+	if appErr != nil {
+		return fmt.Errorf("failed to store user: %w", appErr)
+	}
+
+	return nil
+}
+
+func (s *PluginStore) GetUser(mattermostUserID string) (*User, error) {
+	userBytes, appErr := s.API.KVGet(getUserKey(mattermostUserID))
+	if appErr != nil {
+		return nil, fmt.Errorf("failed to get user: %w", appErr)
+	}
+
+	var user User
+	err := json.Unmarshal(userBytes, &user)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal user: %w", err)
+	}
+	return &user, nil
+}
+
+func (s *PluginStore) StoreAppID(appID string) error {
+	appErr := s.API.KVSet(getAppIDKey(), []byte(appID))
+	if appErr != nil {
+		return fmt.Errorf("failed to store app ID: %w", appErr)
+	}
+
+	return nil
+}
+
+func (s *PluginStore) GetAppID() (string, error) {
+	appIDBytes, appErr := s.API.KVGet(getAppIDKey())
+	if appErr != nil {
+		return "", fmt.Errorf("failed to get app ID: %w", appErr)
+	}
+
+	if appIDBytes == nil {
+		return "", fmt.Errorf("app ID not found")
+	}
+
+	return string(appIDBytes), nil
+}
+
+func getUserKey(mattermostUserID string) string {
+	return fmt.Sprintf("user:%s", mattermostUserID)
+}
+
+func getAppIDKey() string {
+	return "appID"
+}

--- a/server/store/pluginstore/store.go
+++ b/server/store/pluginstore/store.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package pluginstore
 
 import (


### PR DESCRIPTION
#### Summary
- [fix: redirect iframe to site url if there's an error](https://github.com/mattermost/mattermost-plugin-msteams/commit/4d4b49da5cc02a8871500c14d7132cc2f12770af): We weren't catching errors on the `getContext` call, leaving the frame in `about:blank`.
- [fix: retrieve the correct property from the user](https://github.com/mattermost/mattermost-plugin-msteams/commit/a83e5e5fe37711df3fe31b25ddada58b9e90ccea): We were storing the object id as `oid` but trying to use it as `user_id`, breaking the login flow.
  - @wiggin77 you were hitting this, that's why SSO wasn't working on your app
- [feat: store user metadata in the plugin kvstore](https://github.com/mattermost/mattermost-plugin-msteams/pull/815/commits/46d3b7569c6e82a5f3816d508f66a43690d3db7f)