### PR TITLE
feat: check set up audience if noroute is set

### DIFF
--- a/server/iframe.go
+++ b/server/iframe.go
@@ -168,6 +168,10 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// check if the `noroute` query param is set, which will skip the routing.
+	noroute := false
+	_, noroute = r.URL.Query()["noroute"]
+
 	config := a.p.apiClient.Configuration.GetConfig()
 
 	enableDeveloper := config.ServiceSettings.EnableDeveloper
@@ -178,7 +182,17 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 
 	// Validate the token in the request, handling all errors if invalid.
 	expectedTenantIDs := []string{a.p.getConfiguration().TenantID}
-	claims, validationErr := validateToken(a.p.tabAppJWTKeyFunc, token, expectedTenantIDs, enableDeveloper != nil && *enableDeveloper, *config.ServiceSettings.SiteURL, a.p.configuration.ClientID)
+	params := validateTokenParams{
+		jwtKeyFunc:        a.p.tabAppJWTKeyFunc,
+		token:             token,
+		expectedTenantIDs: expectedTenantIDs,
+		enableDeveloper:   enableDeveloper != nil && *enableDeveloper,
+		siteURL:           *config.ServiceSettings.SiteURL,
+		clientID:          a.p.configuration.ClientID,
+		disableRouting:    noroute,
+	}
+
+	claims, validationErr := validateToken(params)
 	if validationErr != nil {
 		handleErrorWithCode(logger, w, validationErr.StatusCode, validationErr.Message, validationErr.Err)
 		return

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -182,7 +182,7 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 
 	// Validate the token in the request, handling all errors if invalid.
 	expectedTenantIDs := []string{a.p.getConfiguration().TenantID}
-	params := validateTokenParams{
+	params := &validateTokenParams{
 		jwtKeyFunc:        a.p.tabAppJWTKeyFunc,
 		token:             token,
 		expectedTenantIDs: expectedTenantIDs,

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -34,8 +34,6 @@ func (ve validationError) Error() string {
 }
 
 type validateTokenParams struct {
-	// JWT token to validate
-	Token             string
 	jwtKeyFunc        keyfunc.Keyfunc
 	token             string
 	expectedTenantIDs []string

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -33,6 +33,18 @@ func (ve validationError) Error() string {
 	return ve.Message
 }
 
+type validateTokenParams struct {
+	// JWT token to validate
+	Token             string
+	jwtKeyFunc        keyfunc.Keyfunc
+	token             string
+	expectedTenantIDs []string
+	enableDeveloper   bool
+	siteURL           string
+	clientID          string
+	disableRouting    bool
+}
+
 func setupJWKSet() (keyfunc.Keyfunc, context.CancelFunc) {
 	// Setup JWK set to assist in verifying JWTs passed from Microsoft Teams.
 	ctx, cancelCtx := context.WithCancel(context.Background())
@@ -46,13 +58,13 @@ func setupJWKSet() (keyfunc.Keyfunc, context.CancelFunc) {
 	return k, cancelCtx
 }
 
-func validateToken(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs []string, enableDeveloper bool, siteURL, clientID string) (jwt.MapClaims, *validationError) {
-	if token == "" && enableDeveloper {
+func validateToken(params validateTokenParams) (jwt.MapClaims, *validationError) {
+	if params.token == "" && params.enableDeveloper {
 		logrus.Warn("Skipping token validation check for empty token since developer mode enabled")
 		return nil, nil
 	}
 
-	if jwtKeyFunc == nil {
+	if params.jwtKeyFunc == nil {
 		return nil, &validationError{
 			StatusCode: http.StatusInternalServerError,
 			Message:    "Failed to initialize token validation",
@@ -85,29 +97,29 @@ func validateToken(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs [
 		// There's no WithNotBefore() helper, but the library always verifies if the claim is present.
 	}
 
-	mmServerURL, err := url.Parse(siteURL)
+	mmServerURL, err := url.Parse(params.siteURL)
 	if err != nil {
-		logrus.WithError(err).WithField("site_url", siteURL).Warn("Failed to parse site URL, check your system console")
+		logrus.WithError(err).WithField("site_url", params.siteURL).Warn("Failed to parse site URL, check your system console")
 		return nil, &validationError{
 			StatusCode: http.StatusUnauthorized,
 			Message:    "Failed to authenticate due to Mattermost server missconfiguration. Contact your system administrator.",
 		}
 	}
 
-	noRouteParamSet := mmServerURL.Query().Has("noroute")
-
 	// Verify that this token was signed for the expected app, unless developer mode is enabled.
-	if enableDeveloper {
+	// If routing is disabled, then use this server's domain and client to verify the audience,
+	// otherwise use Community's domain and client, as it will route to the correct server.
+	if params.enableDeveloper {
 		logrus.Warn("Skipping aud claim check for token since developer mode enabled")
-	} else if noRouteParamSet {
-		options = append(options, jwt.WithAudience(fmt.Sprintf(ExpectedAudienceFmt, mmServerURL.Host, clientID)))
+	} else if params.disableRouting {
+		options = append(options, jwt.WithAudience(fmt.Sprintf(ExpectedAudienceFmt, mmServerURL.Host, params.clientID)))
 	} else {
 		options = append(options, jwt.WithAudience(ExpectedAudience))
 	}
 
 	parsed, err := jwt.Parse(
-		token,
-		jwtKeyFunc.Keyfunc,
+		params.token,
+		params.jwtKeyFunc.Keyfunc,
 		options...,
 	)
 	if err != nil {
@@ -134,7 +146,7 @@ func validateToken(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs [
 		"aud":                 claims["aud"],
 		"tid":                 claims["tid"],
 		"oid":                 claims["oid"],
-		"expected_tenant_ids": expectedTenantIDs,
+		"expected_tenant_ids": params.expectedTenantIDs,
 	})
 
 	// Verify the iat was present. The library is configured above to check
@@ -174,11 +186,11 @@ func validateToken(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs [
 		}
 	}
 
-	for _, expectedTenantID := range expectedTenantIDs {
+	for _, expectedTenantID := range params.expectedTenantIDs {
 		if claims["tid"] == expectedTenantID {
 			logger.Info("Validated token, and authorized request from matching tenant")
 			return claims, nil
-		} else if enableDeveloper && expectedTenantID == "*" {
+		} else if params.enableDeveloper && expectedTenantID == "*" {
 			logger.Warn("Validated token, but authorized request from wildcard tenant since developer mode enabled")
 			return claims, nil
 		}

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -56,7 +56,7 @@ func setupJWKSet() (keyfunc.Keyfunc, context.CancelFunc) {
 	return k, cancelCtx
 }
 
-func validateToken(params validateTokenParams) (jwt.MapClaims, *validationError) {
+func validateToken(params *validateTokenParams) (jwt.MapClaims, *validationError) {
 	if params.token == "" && params.enableDeveloper {
 		logrus.Warn("Skipping token validation check for empty token since developer mode enabled")
 		return nil, nil

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -111,8 +111,8 @@ func TestValidateToken(t *testing.T) {
 		TestClientID = "app-id"
 	)
 
-	makeValidateTokenParams := func(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs []string, enableDeveloper bool) validateTokenParams {
-		return validateTokenParams{
+	makeValidateTokenParams := func(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs []string, enableDeveloper bool) *validateTokenParams {
+		return &validateTokenParams{
 			jwtKeyFunc:        jwtKeyFunc,
 			token:             token,
 			expectedTenantIDs: expectedTenantIDs,

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -122,7 +122,12 @@ func TestValidateToken(t *testing.T) {
 		}
 	}
 
-	runPermutations(t, false, func(t *testing.T, enableDeveloper bool) {
+	type permutations struct {
+		EnableDeveloper bool
+	}
+
+	runPermutations(t, permutations{}, func(t *testing.T, permutation permutations) {
+		enableDeveloper := permutation.EnableDeveloper
 		t.Run("empty authorization header", func(t *testing.T) {
 			_, _, jwtKeyFunc := makeKeySet(t)
 			params := makeValidateTokenParams(jwtKeyFunc, "", []string{}, enableDeveloper)

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -163,7 +164,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 				"tid": tid,
 			})
 			jwtToken.Header[jwkset.HeaderKID] = keyWithoutAlgID
@@ -184,7 +185,7 @@ func TestValidateToken(t *testing.T) {
 			token := newToken(t, priv, jwt.MapClaims{
 				"exp": future(),
 				"nbf": past(),
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 				"tid": tid,
 			})
 			expectedTenantIDs := []string{tid}
@@ -202,7 +203,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": "invalid",
 				"exp": future(),
 				"nbf": past(),
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 				"tid": tid,
 			})
 			expectedTenantIDs := []string{tid}
@@ -220,7 +221,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": future(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 				"tid": tid,
 			})
 			expectedTenantIDs := []string{tid}
@@ -238,7 +239,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"nbf": past(),
 				"tid": tid,
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 			})
 			expectedTenantIDs := []string{tid}
 
@@ -256,7 +257,7 @@ func TestValidateToken(t *testing.T) {
 				"exp": "invalid",
 				"nbf": past(),
 				"tid": tid,
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 			})
 			expectedTenantIDs := []string{tid}
 
@@ -274,7 +275,7 @@ func TestValidateToken(t *testing.T) {
 				"exp": past(),
 				"nbf": past(),
 				"tid": tid,
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 			})
 			expectedTenantIDs := []string{tid}
 
@@ -291,7 +292,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"tid": tid,
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 			})
 			expectedTenantIDs := []string{tid}
 
@@ -309,7 +310,7 @@ func TestValidateToken(t *testing.T) {
 				"exp": future(),
 				"nbf": "invalid",
 				"tid": tid,
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 			})
 			expectedTenantIDs := []string{tid}
 
@@ -327,7 +328,7 @@ func TestValidateToken(t *testing.T) {
 				"exp": future(),
 				"nbf": future(),
 				"tid": tid,
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 			})
 			expectedTenantIDs := []string{tid}
 
@@ -366,7 +367,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 				"tid": wrongTid,
 			})
 			expectedTenantIDs := []string{}
@@ -385,7 +386,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 				"tid": wrongTid,
 			})
 			expectedTenantIDs := []string{expectedTid}
@@ -405,7 +406,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 				"tid": wrongTid,
 			})
 			expectedTenantIDs := []string{expectedTid1, expectedTid2}
@@ -458,7 +459,7 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, "example.com", "app-id"),
 				"tid": developerTid,
 			})
 			expectedTenantIDs := []string{"*"}


### PR DESCRIPTION
#### Summary
Use the `noroute` param in the backend to determine if we need to validate the audience against community or to the set up parameters in the plugin configuration.
