### PR TITLE
combine EnableDeveloper and EnableTesting

### DIFF
--- a/server/iframe.go
+++ b/server/iframe.go
@@ -174,7 +174,11 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 
 	config := a.p.apiClient.Configuration.GetConfig()
 
-	enableDeveloper := config.ServiceSettings.EnableDeveloper
+	enableDeveloperAndTesting := false
+	if config.ServiceSettings.EnableDeveloper != nil && *config.ServiceSettings.EnableDeveloper &&
+		config.ServiceSettings.EnableTesting != nil && *config.ServiceSettings.EnableTesting {
+		enableDeveloperAndTesting = true
+	}
 
 	// Ideally we'd accept the token via an Authorization header, but for now get it from the query string.
 	// token := r.Header.Get("Authorization")
@@ -183,13 +187,13 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 	// Validate the token in the request, handling all errors if invalid.
 	expectedTenantIDs := []string{a.p.getConfiguration().TenantID}
 	params := &validateTokenParams{
-		jwtKeyFunc:        a.p.tabAppJWTKeyFunc,
-		token:             token,
-		expectedTenantIDs: expectedTenantIDs,
-		enableDeveloper:   enableDeveloper != nil && *enableDeveloper,
-		siteURL:           *config.ServiceSettings.SiteURL,
-		clientID:          a.p.configuration.ClientID,
-		disableRouting:    noroute,
+		jwtKeyFunc:                a.p.tabAppJWTKeyFunc,
+		token:                     token,
+		expectedTenantIDs:         expectedTenantIDs,
+		enableDeveloperAndTesting: enableDeveloperAndTesting,
+		siteURL:                   *config.ServiceSettings.SiteURL,
+		clientID:                  a.p.configuration.ClientID,
+		disableRouting:            noroute,
 	}
 
 	claims, validationErr := validateToken(params)

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -113,21 +113,21 @@ func TestValidateToken(t *testing.T) {
 
 	makeValidateTokenParams := func(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs []string, enableDeveloper bool) *validateTokenParams {
 		return &validateTokenParams{
-			jwtKeyFunc:        jwtKeyFunc,
-			token:             token,
-			expectedTenantIDs: expectedTenantIDs,
-			enableDeveloper:   enableDeveloper,
-			siteURL:           TestSiteURL,
-			clientID:          TestClientID,
+			jwtKeyFunc:                jwtKeyFunc,
+			token:                     token,
+			expectedTenantIDs:         expectedTenantIDs,
+			enableDeveloperAndTesting: enableDeveloper,
+			siteURL:                   TestSiteURL,
+			clientID:                  TestClientID,
 		}
 	}
 
 	type permutations struct {
-		EnableDeveloper bool
+		EnableDeveloperAndTesting bool
 	}
 
 	runPermutations(t, permutations{}, func(t *testing.T, permutation permutations) {
-		enableDeveloper := permutation.EnableDeveloper
+		enableDeveloper := permutation.EnableDeveloperAndTesting
 		t.Run("empty authorization header", func(t *testing.T) {
 			_, _, jwtKeyFunc := makeKeySet(t)
 			params := makeValidateTokenParams(jwtKeyFunc, "", []string{}, enableDeveloper)


### PR DESCRIPTION
#### Summary
Require the `ServiceSettings.EnableDeveloper` and `ServiceSettings.EnableTesting` flags to allow local development mode that doesn't enforce JWT validation.

#### Ticket Link
None