### PR TITLE
MM-63675: Fix nil pointer dereference in GetFileSizeAndDownloadURL

### DIFF
--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -1487,14 +1487,28 @@ func (tc *ClientImpl) GetFileSizeAndDownloadURL(weburl string) (int64, string, e
 	if err != nil {
 		return 0, "", NormalizeGraphAPIError(err)
 	}
-	downloadURL, ok := item.GetAdditionalData()["@microsoft.graph.downloadUrl"]
+
+	// Check for nil additional data
+	additionalData := item.GetAdditionalData()
+	if additionalData == nil {
+		return 0, "", errors.New("additional data is nil")
+	}
+
+	downloadURL, ok := additionalData["@microsoft.graph.downloadUrl"]
 	if !ok || downloadURL == nil {
 		return 0, "", errors.New("downloadUrl not found")
 	}
 
 	resultDownloadURL := ""
-	if downloadURL.(*string) != nil {
-		resultDownloadURL = *(downloadURL.(*string))
+	// Safely type assert and dereference
+	if downloadURLStrPtr, ok := downloadURL.(*string); ok && downloadURLStrPtr != nil {
+		resultDownloadURL = *downloadURLStrPtr
+	} else if downloadURLStr, ok := downloadURL.(string); ok {
+		resultDownloadURL = downloadURLStr
+	}
+
+	if resultDownloadURL == "" {
+		return 0, "", errors.New("unable to extract download URL")
 	}
 
 	fileSize := item.GetSize()
@@ -2231,6 +2245,7 @@ func checkGroupChat(c models.Chatable, userIDs []string) *clientmodels.Chat {
 
 	return nil
 }
+
 func (tc *ClientImpl) SendUserActivity(userIDs []string, activityType, message string, webURL url.URL, params map[string]string) error {
 	keyValuePairs := []models.KeyValuePairable{}
 	for k, v := range params {


### PR DESCRIPTION
## Summary
- Fixed nil pointer dereference in GetFileSizeAndDownloadURL when processing file attachments
- Added proper error handling for nil additionalData
- Added safer type assertion for downloadURL that handles both string and *string types 

## Jira Ticket
https://mattermost.atlassian.net/browse/MM-63675

## Related PRs
N/A