### PR TITLE
skip assets.go when building (#814)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,7 @@ ifneq ($(wildcard NOTICE.txt),)
 endif
 ifneq ($(wildcard $(ASSETS_DIR)/.),)
 	cp -r $(ASSETS_DIR) dist/$(PLUGIN_ID)/
+	rm -f dist/$(PLUGIN_ID)/$(ASSETS_DIR)/assets.go
 endif
 ifneq ($(HAS_PUBLIC),)
 	cp -r public dist/$(PLUGIN_ID)/


### PR DESCRIPTION
#### Summary
Recover https://github.com/mattermost/mattermost-plugin-msteams/pull/814 after the reset.

#### Ticket Link
None